### PR TITLE
VM-container-*: Added test for update process using nullos

### DIFF
--- a/resources/VM-container-commands.sh
+++ b/resources/VM-container-commands.sh
@@ -242,3 +242,7 @@ cmd_control_update_config() {
 }
 
 
+cmd_control_push_guestos_config() {
+	do_test_cmd_output "/usr/sbin/control push_guestos_config $1" "response: $2"
+}
+

--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -380,6 +380,86 @@ echo "STATUS: Prepared c0.conf:"
 echo "$(cat ./c0.conf)"
 
 
+cat > ./nullos-1.conf << EOF
+name: "nullos"
+hardware: "x86"
+version: 1
+init_path: "/sbin/init"
+init_param: "splash"
+mounts {
+	image_file: "root"
+	mount_point: "/"
+	fs_type: "squashfs"
+	mount_type: SHARED_RW
+	image_size: 1073741824
+	image_sha1: "2a492f15396a6768bcbca016993f4b4c8b0b5307"
+	image_sha2_256: "49bc20df15e412a64472421e13fe86ff1c5165e18b2afccf160d4dc19fe68a14"
+	image_verity_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+}
+description {
+	en: "null os just for update testing 1GB root.img (x86)"
+}
+update_base_url: "file://$update_base_url"
+build_date: "$(date +%F%T%Z -u)"
+EOF
+
+cat > ./nullos-2.conf << EOF
+name: "nullos"
+hardware: "x86"
+version: 2
+init_path: "/sbin/init"
+init_param: "splash"
+mounts {
+	image_file: "root"
+	mount_point: "/"
+	fs_type: "squashfs"
+	mount_type: SHARED_RW
+	image_size: 2147483648
+	image_sha1: "91d50642dd930e9542c39d36f0516d45f4e1af0d"
+	image_sha2_256: "a7c744c13cc101ed66c29f672f92455547889cc586ce6d44fe76ae824958ea51"
+	image_verity_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+}
+description {
+	en: "null os just for update testing 2GB root.img (x86)"
+}
+update_base_url: "file://$update_base_url"
+build_date: "$(date +%F%T%Z -u)"
+EOF
+
+cat > ./nullos-3.conf << EOF
+name: "nullos"
+hardware: "x86"
+version: 3
+init_path: "/sbin/init"
+init_param: "splash"
+mounts {
+	image_file: "root"
+	mount_point: "/"
+	fs_type: "squashfs"
+	mount_type: SHARED_RW
+	image_size: 3221225472
+	image_sha1: "6e7f6dca8def40df0b21f58e11c1a41c3e000285"
+	image_sha2_256: "305b66a59d15b252092fbda9d09711230c429f351897cbd430e7b55a35fd3b97"
+	image_verity_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+}
+description {
+	en: "null os just for update testing 3GB root.img (x86)"
+}
+update_base_url: "file://$update_base_url"
+build_date: "$(date +%F%T%Z -u)"
+EOF
+
+
+echo "STATUS: Prepared nullos-1.conf:"
+echo "$(cat ./nullos-1.conf)"
+
+echo "STATUS: Prepared nullos-2.conf:"
+echo "$(cat ./nullos-2.conf)"
+
+echo "STATUS: Prepared nullos-3.conf:"
+echo "$(cat ./nullos-3.conf)"
+
+
 echo "PKI_DIR there?: $PKI_DIR"
 # Sign signedcontainer{1,2}.conf, c0.conf (enforced in production and ccmode images)
 if [[ -d "$PKI_DIR" ]];then
@@ -436,6 +516,14 @@ if [[ -d "$PKI_DIR" ]];then
 
 	echo "bash \"$signing_script\" \"./c0.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 	bash "$signing_script" "./c0.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
+
+
+	echo "STATUS: Signing guestos configuration files using using PKI at ${PKI_DIR} and $signing_script"
+
+	for I in $(seq 1 3); do
+		echo "bash \"$signing_script\" \"./nullos-${I}.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
+		bash "$signing_script" "./nullos-${I}.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
+	done
 else
 	echo "ERROR: No test PKI found at $PKI_DIR, exiting..."
 	exit 1
@@ -471,6 +559,26 @@ for I in $(seq 1 10) ;do
 done
 }
 
+do_copy_update_configs(){
+# Copy test guestos configs for update to VM
+for I in $(seq 1 10) ;do
+	echo "STATUS: Trying to copy GuestOS configs to image"
+
+	FILES=" nullos-1.conf nullos-1.sig nullos-1.cert \
+		nullos-2.conf nullos-2.sig nullos-2.cert \
+		nullos-3.conf nullos-3.sig nullos-3.cert"
+
+	if scp $SCP_OPTS $FILES root@127.0.0.1:/tmp/;then
+		echo "STATUS: scp was successful"
+		break
+	elif ! [ $I -eq 10 ];then
+		echo "STATUS: scp failed, retrying..."
+	else
+		echo "STATUS: Failed to copy nullos GuestOS configs to VM, exiting..."
+		err_fetch_logs
+	fi
+done
+}
 
 do_test_complete() {
 	CONTAINER="$1"
@@ -574,6 +682,29 @@ do_test_provisioning() {
 
 	echo "STATUS: Check device reduced command set"
 	cmd_control_set_provisioned "CMD_UNSUPPORTED"
+}
+
+do_test_update() {
+	GUESTOS_NAME="$1"
+	GUESTOS_VERSION="$2"
+
+	echo "STATUS: ########## Starting guestos update test suite, GUESTOS=${GUESTOS_NAME}, VERSION=${GUESTOS_VERSION} ##########"
+
+	let "image_size_by_os_version = $GUESTOS_VERSION * 1024"
+
+	ssh ${SSH_OPTS} "mkdir -p /${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}"
+	cmd_control_push_guestos_config "/tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.conf /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.sig /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.cert" "GUESTOS_MGR_INSTALL_FAILED"
+
+	ssh ${SSH_OPTS} "dd if=/dev/zero of=/${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}/root.img bs=1M count=${image_size_by_os_version}"
+	echo "ssh ${SSH_OPTS} \"dd if=/dev/zero of=/${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}/root.img bs=1M count=${image_size_by_os_version}\""
+	ssh ${SSH_OPTS} "dd if=/dev/zero of=/${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}/root.hash.img bs=1M count=${GUESTOS_VERSION}"
+
+	echo "ssh ${SSH_OPTS} \"ls -lh /${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}\""
+	ssh ${SSH_OPTS} "ls -lh /${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}"
+
+	cmd_control_push_guestos_config "/tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.conf /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.sig /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.cert" "GUESTOS_MGR_INSTALL_COMPLETED"
+
+	ssh ${SSH_OPTS} "rm -r /${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}"
 }
 
 
@@ -878,6 +1009,8 @@ echo "STATUS: extracting current installed OS version"
 installed_guestos_version="$(cmd_control_get_guestos_version trustx-coreos)"
 echo "Found OS version: $installed_guestos_version"
 
+update_base_url="var/volatile/tmp"
+
 # Prepare tests
 # -----------------------------------------------
 echo "STATUS: ########## Preparing tests ##########"
@@ -942,7 +1075,6 @@ if [[ -z "${SCHSM}" ]];then
 	cmd_control_list_container "signedcontainer2"
 fi
 
-
 sync_to_disk
 
 sync_to_disk
@@ -976,6 +1108,7 @@ if ! [[ -z "${SCHSM}" ]];then
 	ssh ${SSH_OPTS} 'echo "VM USB Devices: " && lsusb' 2>&1
 fi
 
+do_copy_update_configs
 
 # Start tests
 # -----------------------------------------------
@@ -989,6 +1122,8 @@ else
 	do_test_complete "signedcontainer1" "n" "y"
 fi
 
+do_test_update "nullos" "1"
+do_test_update "nullos" "2"
 
 
 cmd_control_reboot
@@ -997,6 +1132,9 @@ cmd_control_reboot
 #sleep 5
 
 wait_vm
+
+do_copy_configs
+do_copy_update_configs
 
 #echo "Waiting for USB devices to become ready in QEMU"
 #sleep 5
@@ -1009,6 +1147,7 @@ else
 	do_test_complete "signedcontainer1" "y" "y"
 fi
 
+do_test_update "nullos" "3"
 
 do_test_provisioning
 

--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -83,7 +83,7 @@ def call(Map target) {
 		echo "BB_SIGNATURE_HANDLER = \\\"OEBasicHash\\\"" >> conf/local.conf
 		echo "BB_HASHSERVE = \\\"\\\"" >> conf/local.conf
 
-		echo 'TRUSTME_DATAPART_EXTRA_SPACE="5000"' >> conf/local.conf
+		echo 'TRUSTME_DATAPART_EXTRA_SPACE="10000"' >> conf/local.conf
 
 		if [[ "apalis-imx8 tqma8mpxl" =~ "${GYROID_MACHINE}" ]]; then
 			# when building for NXP machines you have to accept the Freescale EULA


### PR DESCRIPTION
Generate configs for nullos in version 1 to 3. Use version to indicate 1GB, 2GB, 3GB test images. Image files are raw images with all blocks set to zero. The Guestos configs are generated similarity to container test configs and signed on build host with recalculated values for the image. The corresponding image files are generated on demand by 'dd' using on "/var/volatile/tmp" in the running c0 instance.