### PR TITLE
vars/stepIntegrationTest: Fix log file archiving

### DIFF
--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -35,7 +35,7 @@ fetch_logs() {
 	if [ -z "${LOG_DIR}" ];then
 		echo "-l / --log-dir not specified, skipping log file retrieval"
 	else
-		mkdir "${LOG_DIR}"
+		mkdir -p "${LOG_DIR}"
 		skip=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $2}')
 		sectors=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $3}')
 		dd if=${PROCESS_NAME}.img of=${PROCESS_NAME}.data bs=512 skip=${skip} count=${sectors}
@@ -721,7 +721,7 @@ while [[ $# > 0 ]]; do
       ;;
     -l| --log-dir)
       shift
-      LOG_DIR="$(readlink -v -f $1)"
+      LOG_DIR="$(readlink -v -m $1)"
       shift
       ;;
 

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -48,13 +48,15 @@ def integrationTestX86(Map target = [:]) {
 		writeFile file: "${target.workspace}/VM-container-tests.sh", text: "${testscript}"
 		writeFile file: "${target.workspace}/VM-container-commands.sh", text: "${testcommands}"
 
-		sh label: "Perform integration test", script: """
-			bash ${target.workspace}/VM-container-tests.sh --mode "${test_mode}" --dir "${target.workspace}" --image trustmeimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/cml_logs" ${schsm_opts}
+		catchError(message: 'Integration test failed', stageResult: 'FAILURE') {
+			sh label: "Perform integration test", script: """
+				bash ${target.workspace}/VM-container-tests.sh --mode "${test_mode}" --dir "${target.workspace}" --image trustmeimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/out-${target.buildtype}/cml_logs" ${schsm_opts}
 		"""
+		}
 	}
 
 	echo "Archiving CML logs"
-	archiveArtifacts artifacts: 'out-**/cml_logs/**, cml_logs/**', fingerprint: true, allowEmptyArchive: true
+	archiveArtifacts artifacts: 'out-**/cml_logs/**', fingerprint: true, allowEmptyArchive: true
 }
 
 @Field def integrationTestMap = ["genericx86-64": this.&integrationTestX86];


### PR DESCRIPTION
This PR re-adds the build type to the directory path holding the CML logs from test runs.