### PR TITLE
stepBuildImage: Switch version of  meta-tmedbg

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -57,7 +57,7 @@ def call(Map target) {
 			echo "Preparing Yocto workdir for dev mode build with sanitizers enabled"
 			ENABLE_SCHSM="1"
 			TRUSTME_SANITIZERS="1"
-			git clone -b testing https://github.com/gyroidos/meta-tmedbg
+			git clone https://github.com/gyroidos/meta-tmedbg
 		else
 			echo "Error, unkown ${target.buildtype}, exiting..."
 			exit 1


### PR DESCRIPTION
This PR addapts stepBuildImage such that the default version of meta-tmedbg is used in 'asan' buils.