### PR TITLE
resources/VM-container-tests: perform extended update test

### DIFF
--- a/resources/VM-container-commands.sh
+++ b/resources/VM-container-commands.sh
@@ -131,6 +131,12 @@ cmd_control_stop() {
 
 }
 
+cmd_control_stop_after_rename() {
+	do_test_cmd_output "/usr/sbin/control stop $1 --key=$3" "CONTAINER_STOP_OK"
+	do_wait_stopped "$2"
+	#sleep 2
+}
+
 cmd_control_stop_error_notrunning() {
 	do_test_cmd_output "/usr/sbin/control stop $1 --key=$2" "CONTAINER_STOP_FAILED_NOT_RUNNING"
 	do_wait_stopped "$1"

--- a/resources/testdata.sh
+++ b/resources/testdata.sh
@@ -62,6 +62,37 @@ mac_filter: "00:00:00:00:00:14"
 }
 EOF
 
+cat > ./signedcontainer1_rename.conf << EOF
+name: "signedcontainer1-rename"
+guest_os: "trustx-coreos"
+guestos_version: $installed_guestos_version
+assign_dev: "c 4:2 rwm"
+image_sizes {
+  image_name: "etc"
+  image_size: 10
+}
+fifos: "signedfifo11"
+fifos: "signedfifo12"
+
+vnet_configs {
+if_name: "vnet0"
+configure: false
+if_rootns_name: "r_1"
+}
+vnet_configs {
+if_name: "vnet1"
+configure: false
+if_rootns_name: "r_2"
+}
+
+
+net_ifaces {
+netif: "00:00:00:00:00:11"
+mac_filter: "AA:AA::AA:AA:AA"
+mac_filter: "00:00:00:00:00:14"
+}
+EOF
+
 cat > ./signedcontainer2.conf << EOF
 name: "signedcontainer2"
 guest_os: "trustx-coreos"
@@ -167,6 +198,44 @@ mac_filter: "00:00:00:00:00:14"
 }
 EOF
 
+cat > ./signedcontainer1_rename.conf << EOF
+name: "signedcontainer1-rename"
+guest_os: "trustx-coreos"
+guestos_version: $installed_guestos_version
+assign_dev: "c 4:2 rwm"
+token_type: USB
+usb_configs {
+  id: "04e6:5816"
+  serial: "${SCHSM}"
+  assign: true
+  type: TOKEN
+}
+image_sizes {
+  image_name: "etc"
+  image_size: 10
+}
+fifos: "signedfifo11"
+fifos: "signedfifo12"
+
+vnet_configs {
+if_name: "vnet0"
+configure: false
+if_rootns_name: "r_1"
+}
+vnet_configs {
+if_name: "vnet1"
+configure: false
+if_rootns_name: "r_2"
+}
+
+
+net_ifaces {
+netif: "00:00:00:00:00:11"
+mac_filter: "AA:AA::AA:AA:AA"
+mac_filter: "00:00:00:00:00:14"
+}
+EOF
+
 cat > ./signedcontainer2.conf << EOF
 name: "signedcontainer2"
 guest_os: "trustx-coreos"
@@ -210,6 +279,8 @@ echo "$(cat ./signedcontainer1.conf)"
 echo_status "Prepared signedcontainer1_update.conf:"
 echo "$(cat ./signedcontainer1_update.conf)"
 
+echo_status "Prepared signedcontainer1_rename.conf:"
+echo "$(cat ./signedcontainer1_rename.conf)"
 
 
 echo_status "Prepared signedcontainer2.conf:"
@@ -361,6 +432,9 @@ if [[ -d "$PKI_DIR" ]];then
 	echo "bash \"$signing_script\" \"./signedcontainer1_update.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 	bash "$signing_script" "./signedcontainer1_update.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
 
+	echo "bash \"$signing_script\" \"./signedcontainer1_rename.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
+	bash "$signing_script" "./signedcontainer1_rename.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
+
 	echo "bash \"$signing_script\" \"./signedcontainer2.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 	bash "$signing_script" "./signedcontainer2.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
 
@@ -379,7 +453,7 @@ else
 	exit 1
 fi
 
-echo_status "Signed signedcontainer{1,2}.conf, signedcontainer1_update.conf, c0.conf:"
+echo_status "Signed signedcontainer{1,2}.conf, signedcontainer1_{update,rename}.conf, c0.conf:"
 }
 
 do_copy_configs(){
@@ -391,10 +465,13 @@ for I in $(seq 1 10) ;do
 	if [ -f signedcontainer1.sig ];then
 		FILES="testcontainer.conf signedcontainer1.conf signedcontainer1.sig signedcontainer1.cert \
 			   signedcontainer1_update.conf signedcontainer1_update.sig signedcontainer1_update.cert \
+			   signedcontainer1_rename.conf signedcontainer1_rename.sig signedcontainer1_rename.cert \
 			   signedcontainer2.conf signedcontainer2.sig signedcontainer2.cert \
 			   c0.conf c0.sig c0.cert"
 	else
-		FILES="signedcontainer1.conf signedcontainer1_update.conf signedcontainer2.conf c0.conf"
+		FILES="signedcontainer1.conf signedcontainer1_update.conf signedcontainer2.conf c0.conf \
+			   sigendcontainer1_rename.conf"
+
 	fi
 
 	if scp $SCP_OPTS $FILES root@127.0.0.1:/tmp/;then


### PR DESCRIPTION
This should be merged in conjunction with https://github.com/gyroidos/cml/pull/518

[resources/VM-container-tests: perform extended update test](https://github.com/gyroidos/gyroidos_ci_common/commit/2fad9af54e91d1d681e0a8969837d3ec81c4b27d)

Added new test case which performs following test to trigger
container reload:

0) signedcontainer1 is stopped.
1) Updated config of "signedcontainer1" with new name
   "signedcontainer1-rename"
   This should directly trigger the reload.

2) Start container by name "signedcontainer1-rename"

3) Updated config of "signedcontainer1-rename" with new name
   "signedcontainer1"
   Since container is running, sync state is set to false but reload
   is not trigged, yet.

4) Stop container by name "signedcontainer1-rename"
   This should trigger the reload.

5) Start container by name "signedcontainer1"
   If reload was sucessfull this should work.

6) Stop container by name "signedcontainer1"

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>