### PR TITLE
tree-wide: switched paths and image name to gyroidos

### DIFF
--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -103,7 +103,7 @@ do_test_complete() {
 
 	ssh ${SSH_OPTS} "echo testmessage2 > /dev/fifos/signedfifo2"
 
-	cmd_control_list_guestos "trustx-coreos"
+	cmd_control_list_guestos "gyroidos-coreos"
 
 	cmd_control_remove_error_eexist "nonexistent-container"
 
@@ -222,10 +222,10 @@ then
 
 	if [[ $FORCE == true ]]
 	then
-		bitbake -c clean multiconfig:container:trustx-core
+		bitbake -c clean multiconfig:container:gyroidos-core
 		bitbake -c clean cmld
-		bitbake -c clean trustx-cml-initramfs
-		bitbake -c clean trustx-cml
+		bitbake -c clean gyroidos-cml-initramfs
+		bitbake -c clean gyroidos-cml
 	fi
 
 	if [[ $BRANCH != "" ]]
@@ -234,8 +234,8 @@ then
 		sed -i "s/branch=\${BRANCH}/branch=$BRANCH/g" cmld_git.bbappend
 	fi
 
-	bitbake multiconfig:container:trustx-core
-	bitbake trustx-cml
+	bitbake multiconfig:container:gyroidos-core
+	bitbake gyroidos-cml
 elif [[ -z "${IMGPATH}" ]]
 then
 	if [ ! -d "${BUILD_DIR}" ]
@@ -301,8 +301,8 @@ if ! [[ -z "${IMGPATH}" ]];then
 	echo_status "Testing image at ${IMGPATH}"
 	rsync ${IMGPATH} ${PROCESS_NAME}.img
 else
-	echo_status "Testing image at $(pwd)/tmp/deploy/images/genericx86-64/trustme_image/trustmeimage.img"
-	rsync tmp/deploy/images/genericx86-64/trustme_image/trustmeimage.img ${PROCESS_NAME}.img
+	echo_status "Testing image at $(pwd)/tmp/deploy/images/genericx86-64/gyroidos_image/gyroidosimage.img"
+	rsync tmp/deploy/images/genericx86-64/gyroidos_image/gyroidosimage.img ${PROCESS_NAME}.img
 fi
 
 # Prepare image for test with physical tokens
@@ -340,7 +340,7 @@ for I in $(seq 1 10) ;do
 done
 
 echo_status "extracting current installed OS version"
-installed_guestos_version="$(cmd_control_get_guestos_version trustx-coreos)"
+installed_guestos_version="$(cmd_control_get_guestos_version gyroidos-coreos)"
 echo_status "Found OS version: $installed_guestos_version"
 
 update_base_url="var/volatile/tmp"

--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -89,7 +89,7 @@ wait_vm () {
 start_vm() {
     qemu-system-x86_64 -machine accel=kvm,vmport=off -m 64G -smp 4 -cpu host -bios OVMF.fd \
         -monitor unix:./${PROCESS_NAME}.qemumon,server,nowait \
-        -name trustme-tester,process=${PROCESS_NAME} -nodefaults -nographic \
+        -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \
         -device virtio-rng-pci,rng=id -object rng-random,id=id,filename=/dev/urandom \
         -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd0 \
         -drive if=none,id=hd0,file=${PROCESS_NAME}.img,cache=directsync,format=raw \

--- a/resources/settings.sh
+++ b/resources/settings.sh
@@ -59,7 +59,7 @@ parse_cli() {
         echo "-m, --mode        	Test \"dev\", \"production\", or \"ccmode\" image? Default is \"dev\""
         echo "-e, --enable-schsm	Test with given schsm"
         echo "-k, --skip-rootca	Skip attempt to copy custom root CA to image"
-        echo "-r, --scripts-dir	Specify directory containing signing scripts (trustme_build repo)"
+        echo "-r, --scripts-dir	Specify directory containing signing scripts (gyroidos_build repo)"
         exit 1
         ;;
         -c|--compile)

--- a/resources/store-revisions.sh
+++ b/resources/store-revisions.sh
@@ -212,10 +212,10 @@ if [ "y" == "$CML" ]; then
 	srcrevpath="$(find "$BH_PATH/packages" -wholename '*/cmld/latest_srcrev')"
 	if [ -z "$srcrevpath" ];then
 		echo "Failed to find file */cmld/latest_srcrev in buildhistory, \
-			  attempting to fetch revision from $WS_PATH/trustme/cml."
+			  attempting to fetch revision from $WS_PATH/gyroidos/cml."
 
-		if [ -d "$WS_PATH/trustme/cml" ];then
-			srcrev="$(git -C "$WS_PATH/trustme/cml" rev-parse HEAD)"
+		if [ -d "$WS_PATH/gyroidos/cml" ];then
+			srcrev="$(git -C "$WS_PATH/gyroidos/cml" rev-parse HEAD)"
 			echo "CML revision in EXTERNALSRC build is $srcrev"
 		else
 			echo "Could not find directory holding cml git."

--- a/resources/testdata.sh
+++ b/resources/testdata.sh
@@ -9,7 +9,7 @@ if [[ -z "$SCHSM" ]];then
 
 cat > ./testcontainer.conf << EOF
 name: "testcontainer"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 image_sizes {
@@ -21,7 +21,7 @@ EOF
 
 cat > ./signedcontainer1.conf << EOF
 name: "signedcontainer1"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 image_sizes {
@@ -33,7 +33,7 @@ EOF
 
 cat > ./signedcontainer1_update.conf << EOF
 name: "signedcontainer1"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 image_sizes {
@@ -64,7 +64,7 @@ EOF
 
 cat > ./signedcontainer1_rename.conf << EOF
 name: "signedcontainer1-rename"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 image_sizes {
@@ -95,7 +95,7 @@ EOF
 
 cat > ./signedcontainer2.conf << EOF
 name: "signedcontainer2"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:3 rwm"
 allow_dev: "b 8:* rwm"
@@ -131,7 +131,7 @@ else
 
 cat > ./testcontainer.conf << EOF
 name: "testcontainer"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:5 rwm"
 image_sizes {
@@ -143,7 +143,7 @@ EOF
 
 cat > ./signedcontainer1.conf << EOF
 name: "signedcontainer1"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 token_type: USB
@@ -162,7 +162,7 @@ EOF
 
 cat > ./signedcontainer1_update.conf << EOF
 name: "signedcontainer1"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 token_type: USB
@@ -200,7 +200,7 @@ EOF
 
 cat > ./signedcontainer1_rename.conf << EOF
 name: "signedcontainer1-rename"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:2 rwm"
 token_type: USB
@@ -238,7 +238,7 @@ EOF
 
 cat > ./signedcontainer2.conf << EOF
 name: "signedcontainer2"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:3 rwm"
 fifos: "signedfifo21"
@@ -288,7 +288,7 @@ echo "$(cat ./signedcontainer2.conf)"
 
 cat > ./rmcontainer3.conf << EOF
 name: "rmcontainer3"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:4 rwm"
 image_sizes {
@@ -303,7 +303,7 @@ echo "$(cat ./rmcontainer3.conf)"
 
 cat > ./c0.conf << EOF
 name: "core0"
-guest_os: "trustx-coreos"
+guest_os: "gyroidos-coreos"
 guestos_version: $installed_guestos_version
 assign_dev: "c 4:1 rwm"
 allow_dev: "b 8:* rwm"
@@ -402,22 +402,22 @@ if [[ -d "$PKI_DIR" ]];then
 	if ! [[ -z "${SCRIPTS_DIR}" ]];then
 		scripts_path="${SCRIPTS_DIR}/"
 	elif ! [[ -z "${BUILD_DIR}" ]];then
-		echo_status "--scripts-dir not given, assuming \"../trustme/build\""
-		scripts_path="$(pwd)/../trustme/build"
+		echo_status "--scripts-dir not given, assuming \"../gyroidos/build\""
+		scripts_path="$(pwd)/../gyroidos/build"
 		echo "scripts_path: $scripts_path"
 	else
-		echo_status "--scripts-dir not given, assuming \"./trustme/build\""
-		scripts_path="$(pwd)/trustme/build"
+		echo_status "--scripts-dir not given, assuming \"./gyroidos/build\""
+		scripts_path="$(pwd)/gyroidos/build"
 	fi
 
 	echo "B"
 	if ! [[ -d "$scripts_path" ]];then
-		echo_status "Could not find trustme_build directory at $scripts_path."
+		echo_status "Could not find gyroidos_build directory at $scripts_path."
 		read -r -p "Download from GitHub?" -n 1
 
 		if [[ "$REPLY" == "y" ]];then
 			mkdir -p "$scripts_path"
-			echo_status "Got y, downloading trustme_build repository to $scripts_path"
+			echo_status "Got y, downloading gyroidos_build repository to $scripts_path"
 			git clone https://github.com/gyroidos/gyroidos_build.git "$scripts_path"
 		fi
 	fi

--- a/resources/unit-testing.sh
+++ b/resources/unit-testing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Jenkins executes this script before it builds the trustme image (i.e. pre-yocto).
+# Jenkins executes this script before it builds the gyroidos image (i.e. pre-yocto).
 # If this script exits with a non-zero code, the whole pipeline fails.
 # Right now it is used to execute the unit tests in libcommon
 # However, it can be extended and used for any pre-build-time task (fuzzing, other tests, etc).

--- a/vars/stepInitWs.groovy
+++ b/vars/stepInitWs.groovy
@@ -63,7 +63,7 @@ def call(Map target = [:]) {
 <?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\n\
 <manifest>\n\
 <remove-project name=\\\"\$project\\\" />\n\
-<project path=\\\"trustme/cml\\\" name=\\\"\$project\\\" remote=\\\"gyroidos\\\" revision=\\\"\$revision\\\" />\n\
+<project path=\\\"gyroidos/cml\\\" name=\\\"\$project\\\" remote=\\\"gyroidos\\\" revision=\\\"\$revision\\\" />\n\
 </manifest>" >> .repo/local_manifests/\$project.xml
 			elif [[ "\$line" =~ (\$build_repo)=\$branch_regex ]]; then
 				project="\${BASH_REMATCH[1]}"
@@ -73,7 +73,7 @@ def call(Map target = [:]) {
 <?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\n\
 <manifest>\n\
 <remove-project name=\\\"\$project\\\" />\n\
-<project path=\\\"trustme/build\\\" name=\\\"\$project\\\" remote=\\\"gyroidos\\\" revision=\\\"\$revision\\\" />\n\
+<project path=\\\"gyroidos/build\\\" name=\\\"\$project\\\" remote=\\\"gyroidos\\\" revision=\\\"\$revision\\\" />\n\
 </manifest>" >> .repo/local_manifests/\$project.xml
 			else
 				echo "Could not parse revision for line \$line"

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -13,7 +13,7 @@ def integrationTestX86(Map target = [:]) {
 	step ([$class: 'CopyArtifact',
 		projectName: env.JOB_NAME,
 		selector: target.selector,
-		filter: "out-${target.buildtype}/**/trustmeimage.img.xz, ${target.source_tarball}",
+		filter: "out-${target.buildtype}/**/gyroidosimage.img.xz, ${target.source_tarball}",
 		flatten: true]);
 
 
@@ -33,7 +33,7 @@ def integrationTestX86(Map target = [:]) {
 
 	sh "echo \"Unpacking sources\" && tar -C \"${target.workspace}\" -xf ${target.source_tarball}"
 
-	sh label: "Extract image", script: 'unxz -T0 trustmeimage.img.xz'
+	sh label: "Extract image", script: 'unxz -T0 gyroidosimage.img.xz'
 
 
 	testscript = libraryResource('VM-container-tests.sh')	
@@ -59,7 +59,7 @@ def integrationTestX86(Map target = [:]) {
 				echo "Testing image with mode ${target.test_mode}"
 			fi
 	
-			CML_DBG=n bash ${target.workspace}/VM-container-tests.sh --mode "${target.test_mode}" --dir "${target.workspace}" --image trustmeimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/out-${target.buildtype}/cml_logs" \$schsm_opts ${target.extra_opts ? target.extra_opts : ""}
+			CML_DBG=n bash ${target.workspace}/VM-container-tests.sh --mode "${target.test_mode}" --dir "${target.workspace}" --image gyroidosimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/out-${target.buildtype}/cml_logs" \$schsm_opts ${target.extra_opts ? target.extra_opts : ""}
 		"""
 	}
 


### PR DESCRIPTION
GyroidOS-specific repos are now located at <workspace>/gyroidos/. Also partition names and labels are changed from trustme* to gyroidos*. Further, use variable names called GYROIDOS* instead of TRUSTME*.