### PR TITLE
vars/stepBuildImage: do not checkout meta-tmedbg repo

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -64,7 +64,6 @@ def call(Map target) {
 				cd ${target.workspace}/
 
 				echo "Preparing workspace for build with ASAN, ${WORKSPACE}/out-${BUILDTYPE}"
-				git clone https://github.com/gyroidos/meta-tmedbg
 				bash  ${WORKSPACE}/meta-tmedbg/prepare_ws.sh  ${WORKSPACE}/out-${BUILDTYPE}
 
 				cd ${target.workspace}/out-${target.buildtype}


### PR DESCRIPTION
We need to get this things versioned, thus it is put into the gyroidos repo and the corresponding manifest file there. The checkout is then done in stepInitWs.groovy.