### PR TITLE
VM-management, stepintegrationTests: Print ids

### DIFF
--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -87,6 +87,9 @@ wait_vm () {
 }
 
 start_vm() {
+	id
+	ls -al /dev/kvm || true
+
     qemu-system-x86_64 -machine accel=kvm,vmport=off -m 64G -smp 4 -cpu host -bios OVMF.fd \
         -monitor unix:./${PROCESS_NAME}.qemumon,server,nowait \
         -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \

--- a/vars/stepInitWs.groovy
+++ b/vars/stepInitWs.groovy
@@ -15,6 +15,8 @@ def call(Map target = [:]) {
 
 	echo "Entering stepInitWs with parameters:\n\t workspace: ${target.workspace}\n\t manifest_path: ${target.manifest_path}\n\tmanifest_name: ${target.manifest_name}\n\tgyroid_arch: ${target.gyroid_arch}\n\tgyroid_machine: ${target.gyroid_machine}\n\tselector: ${buildParameter('BUILDSELECTOR')}\n\trebuild_previous: ${target.rebuild_previous}"
 
+	sh 'id'
+
 	utilArchiveBuildNo(workspace: target.workspace, build_number: BUILD_NUMBER)
 
 	def artifact_build_no = utilGetArtifactBuildNo(workspace: target.workspace, selector: target.selector)

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -58,6 +58,9 @@ def integrationTestX86(Map target = [:]) {
 				schsm_opts=""
 				echo "Testing image with mode ${target.test_mode}"
 			fi
+
+			id
+			ls -al /dev/kvm || true
 	
 			CML_DBG=n bash ${target.workspace}/VM-container-tests.sh --mode "${target.test_mode}" --dir "${target.workspace}" --image gyroidosimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/out-${target.buildtype}/cml_logs" \$schsm_opts ${target.extra_opts ? target.extra_opts : ""}
 		"""

--- a/vars/stepWipeWs.groovy
+++ b/vars/stepWipeWs.groovy
@@ -4,5 +4,7 @@ def call(String workspace, String manifest_path) {
 
 	echo "Entering stepWipeWs with parameter ${workspace}"
 
+	sh 'id'
+
 	sh "find ${workspace} -mindepth 1 ! -wholename '${manifest_path}*' -print -delete"
 }


### PR DESCRIPTION
This PR adapts the integration tests to print active group ids regarding /dev/Kvm to ease debugging.