### PR TITLE
vars/stepInitWs.groovy: check if meta-* repo exists before removing

### DIFF
--- a/vars/stepInitWs.groovy
+++ b/vars/stepInitWs.groovy
@@ -49,6 +49,11 @@ def call(Map target = [:]) {
 				project="\${BASH_REMATCH[1]}"
 				revision="refs/pull/\${BASH_REMATCH[2]}/merge"
 
+				if [ -z "`grep \$project ${target.manifest_path}/${target.manifest_name}`" ] && \
+				   [ -z "`grep \$project ${target.manifest_path}/gyroidos-base.xml`" ]; then
+					continue
+				fi
+
 				echo "\
 <?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\n\
 <manifest>\n\


### PR DESCRIPTION
If building with PR set for an meta-gyroidos-* repo, check if it exists. In case the piple is triggered for diffrent machines, but with a PR depending machine repo, this would fail for other machines which do not check out this repo. E.g., one needs a depending PR in meta-gyroidos-nxp but triggers the pipeline through the cml repo. In this case the meta-gyroidos-nxp repo is not in the manifest.xml of the workspace and the remove-project would fail. In that case just continue the loop.