### PR TITLE
resources/VM-management: fix copying of logfiles from gyroidosimage

### DIFF
--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -39,6 +39,9 @@ fetch_logs() {
         sectors=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $3}')
         dd if=${PROCESS_NAME}.img of=${PROCESS_NAME}.data bs=512 skip=${skip} count=${sectors}
         for i in `e2ls ${PROCESS_NAME}.data:/userdata/logs`; do
+            if [ -z "${i##*.current}" ]; then
+                continue;
+            fi
             e2cp ${PROCESS_NAME}.data:/userdata/logs/${i} ${LOG_DIR}/
         done
         echo_status "Retrieved CML logs: $(ls -al ${LOG_DIR})"


### PR DESCRIPTION
e2cp fails on copying links, thus avoid this during copying of log files out of gyroidosimage.

This fixes following ci error:

  Attempt to read block from filesystem resulted in short readError \
  copying file /userdata/logs/cml-daemon.current to [..]/cml_logs//cml-daemon.current

  Error encountered copying files

  script returned exit code 255