### PR TITLE
Shell Options: set -eu for Jenkins shell scripts

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -56,6 +56,7 @@ def call(Map target) {
 		env.GYROIDOS_PLAIN_DATAPART = "${("production" == target.buildtype) || ("ccmode" == target.buildtype) || ("schsm" == target.buildtype) || ("bnse" == target.buildtype) ? '1' : '0'}"
 
 		sh label: 'Prepare build directory', script: """
+			set -eu
 			export LC_ALL=en_US.UTF-8
 			export LANG=en_US.UTF-8
 			export LANGUAGE=en_US.UTF-8
@@ -112,12 +113,14 @@ def call(Map target) {
 	stepStoreRevisions(workspace: target.workspace, buildtype: "${target.buildtype}", manifest_path: target.manifest_path, manifest_name: target.manifest_name, gyroid_machine: target.gyroid_machine)
 
 	sh label: 'Compress gyroidosimage.img', script: """
+		set -eu
 		cd ${target.workspace}/out-${target.buildtype}/tmp/deploy/images/*
 		tar -I "xz -T 0" -C gyroidos_image -cf gyroidosimage.tar.xz --dereference gyroidosimage.img gyroidosimage.img.bmap
 	"""
 
 	if (target.containsKey("build_installer") && "y" == target.build_installer) {
 		sh label: 'Compress gyroidosinstaller.img', script: """
+			set -eu
 			cd ${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/*
 			tar -I "xz -T 0" -C gyroidos_image -cf gyroidosinstaller.tar.xz --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
 		"""

--- a/vars/stepInitWs.groovy
+++ b/vars/stepInitWs.groovy
@@ -28,6 +28,7 @@ def call(Map target = [:]) {
 	stepWipeWs(target.workspace, target.manifest_path)
 
 	sh label: 'Repo init', script: """
+		set -eu
 		cd ${target.workspace}/.manifests
 		git rev-parse --verify jenkins-ci && git branch -D jenkins-ci
 		git checkout -b "jenkins-ci"
@@ -37,6 +38,7 @@ def call(Map target = [:]) {
 	"""
 
 	sh label: 'Parse PRs + repo sync', script: """
+		set -eu
 		mkdir -p .repo/local_manifests
 
 		meta_repos="meta-gyroidos|meta-tmedbg|meta-gyroidos-intel|meta-gyroidos-rpi|meta-gyroidos-nxp|meta-gyroidos-riscv"

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -59,6 +59,7 @@ def integrationTestX86(Map target = [:]) {
 
 	catchError(message: 'Integration test failed', stageResult: 'FAILURE') {
 		sh label: "Perform integration test", script: """
+			set -eu
 			if ! [ -z "${target.hsm_serial}" ];then
 				schsm_opts="--enable-hsm ${target.hsm_serial} ${target.hsm_vid} ${target.hsm_pid} ${target.hsm_pin}"
 
@@ -77,6 +78,7 @@ def integrationTestX86(Map target = [:]) {
 
 	catchError(message: 'ASAN output detected', stageResult: 'FAILURE') {
 		sh label: "Check whether ASAN logs generated", script: """
+			set -eu
 			if ! [ -z "\$(find out-${target.buildtype}/cml_logs -name '*asan*')" ];then
 				echo "Found ASAN logs"
 				exit 1

--- a/vars/stepStoreRevisions.groovy
+++ b/vars/stepStoreRevisions.groovy
@@ -11,7 +11,7 @@ def call(Map target) {
 	writeFile file: "${target.workspace}/store-revisions.sh", text: "${testscript}"
 
 	sh label: 'Creating manifest_revisions.xml and auto.conf', script: """
-
+	set -eu
 	mkdir "${target.workspace}/out-${target.buildtype}/gyroidos_revisions"
 
 	bash "${target.workspace}/store-revisions.sh" -w "${target.workspace}" -m "${target.manifest_path}/${target.manifest_name}" -o "${target.workspace}/out-${target.buildtype}/gyroidos_revisions" -b "${target.workspace}/out-${target.buildtype}/buildhistory" --cml --gyroid_machine "${gyroid_machine}"

--- a/vars/stepUnitTests.groovy
+++ b/vars/stepUnitTests.groovy
@@ -15,6 +15,7 @@ def call(Map target) {
 	writeFile file: "${target.workspace}/unit-testing.sh", text: "${testscript}"
 
 	sh label: 'Perform unit tests', script: """
+		set -eu
 		cd ${target.sourcedir}/common/testdata && bash gen_testvectors.sh
 
 		bash ${target.workspace}/unit-testing.sh ${target.sourcedir}


### PR DESCRIPTION
Configure the shell to behave sane and as expected:
-e ensures that the build aborts when commands fail. Relevant for i.e. mkdir, cd (!)
-u faults if a variable is undefined. Currently, we silently fail to an empty string