### PR TITLE
resources/VM-management: fix sector count retrieval

### DIFF
--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -36,7 +36,7 @@ fetch_logs() {
     else
         mkdir -p "${LOG_DIR}"
         skip=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $2}')
-        sectors=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $3}')
+        sectors=$(/sbin/fdisk -lu ${PROCESS_NAME}.img | tail -n1 | awk '{print $4}')
         dd if=${PROCESS_NAME}.img of=${PROCESS_NAME}.data bs=512 skip=${skip} count=${sectors}
         for i in `e2ls ${PROCESS_NAME}.data:/userdata/logs`; do
             if [ -z "${i##*.current}" ]; then


### PR DESCRIPTION
This is the format of `fdisk -lu`:
```
Device     Boot Start       End   Sectors  Size Id Type
/dev/sda1        2048 120164351 120162304 57.3G  7 HPFS/NTFS/exFAT
```
Currently, we thereby fetch "end" as "sectors". Fix that.

This should fix the reliability of the retrieval of asan logs.