### PR TITLE
shell: rewrite scripts for robustness

### DIFF
--- a/resources/VM-container-commands.sh
+++ b/resources/VM-container-commands.sh
@@ -1,144 +1,85 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-if  [ "y" = "${CML_DBG}" ];then
-	DEBUG="y"
-	set -x
-else
-	DEBUG="n"
-fi
-
-dbg() {
-	if [ "y" = "$DEBUG" ];then
-		echo_status "DEBUG: $1" >&2
-	fi
-}
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 do_wait_running () {
-	echo_status "Wait for container \"$1\" to start (Calling control state)"
-	while [ true ];do
-		STATE="$(ssh ${SSH_OPTS} "/usr/sbin/control state $1" 2>&1)"
-
-		dbg "STATE: $STATE"
-
-		if ! [ -z "$(grep RUNNING <<< \"${STATE}\")" ];then
-			echo_status "Container is running"
+	while true; do
+		STATE="$(ssh "${SSH_OPTS[@]}" "/usr/sbin/control state $1" 2>&1)"
+		edebug "control state $1: $STATE"
+		if [[ "$STATE" == *RUNNING* ]]; then
 			break
-		elif ! [ -z "$(grep STARTING <<< \"${STATE}\")" ] || ! [ -z "$(grep BOOTING <<< \"${STATE}\")" ] ;then
-			printf "."
+		elif [[ "$STATE" == *STARTING* ]] || [[ "$STATE" == *BOOTING* ]]; then
 			sleep 0.1
 		else
-			echo_status "exitcode: $?"
-			echo_error "Check failed, expected \"STARTING\" or \"RUNNING\", got:"
-			echo_status "\"${STATE}\""
-			exit 1
+			die "Expected STARTING/RUNNING for \"$1\", got: ${STATE}"
 		fi
 	done
 }
-
 
 do_wait_stopped () {
-	echo_status "Wait for container \"$1\" to stop (Calling control state)"
-	while [ true ];do
-		STATE="$(ssh ${SSH_OPTS} "/usr/sbin/control state $1" 2>&1)"
-
-		if ! [ -z "$(grep STOPPED <<< \"${STATE}\")" ];then
-			echo_status "Container is stopped"
+	while true; do
+		STATE="$(ssh "${SSH_OPTS[@]}" "/usr/sbin/control state $1" 2>&1)"
+		if [[ "$STATE" == *STOPPED* ]]; then
 			break
-		else
-			printf "."
-			sleep 0.5
 		fi
+		sleep 0.5
 	done
-}
-
-do_check_params() {
-	dbg checking "$1, $2"
-	if [[ -z "$1" || -z "$2" ]];then
-		echo_error "Required parameters missing"
-		exit 1
-	fi
 }
 
 do_test_cmd_output() {
-	do_check_params "$1" "$2"
+	if [[ -z "$1" || -z "$2" ]]; then
+		die "do_test_cmd_output: required parameters missing"
+	fi
 
-	echo_status "\"$1\""
+	OUTPUT="$(ssh "${SSH_OPTS[@]}" "$1" 2>&1)" || true
+	edebug "cmd='$1' output='$OUTPUT'"
 
-	OUTPUT="$(ssh ${SSH_OPTS} "$1" 2>&1)" || true
-	dbg "Command returned $OUTPUT, code: $?"
-
-	if echo_status "$OUTPUT" | grep -q "$2";then
-		dbg "exitcode: $?"
-		echo_status "Check successful"
-		#sleep 2
-	else
-		echo_status "exitcode: $?"
-		echo_error "Check failed, expected \"$2\", got:"
-		echo_status "\"$OUTPUT\""
-		exit 1
+	if ! echo "$OUTPUT" | grep -q "$2"; then
+		eerror "Expected \"$2\" in output of: $1"
+		die "Got: $OUTPUT"
 	fi
 }
 
 do_test_cmd_noutput() {
-	do_check_params "$1" "$2"
-
-	echo_status "executing command \"$1\""
-
-	if OUTPUT="$(ssh ${SSH_OPTS} "$1" 2>&1)";then
-		echo_status "Command returned $OUTPUT, code: $?"
+	if [[ -z "$1" || -z "$2" ]]; then
+		die "do_test_cmd_noutput: required parameters missing"
 	fi
 
+	OUTPUT="$(ssh "${SSH_OPTS[@]}" "$1" 2>&1)" || true
+	edebug "cmd='$1' output='$OUTPUT'"
 
-	if echo_status "$OUTPUT" | grep -q "$2";then
-		echo_status "exitcode: $?"
-		echo_error "Check failed, did not expect \"$2\", got:"
-		echo_status "\"$OUTPUT\""
-		exit 1
-	else
-		dbg "exitcode: $?"
-		echo_status "Check successful"
-		#sleep 2
+	if echo "$OUTPUT" | grep -q "$2"; then
+		eerror "Did not expect \"$2\" in output of: $1"
+		die "Got: $OUTPUT"
 	fi
-
 }
-
 
 
 cmd_control_start() {
 	do_test_cmd_output "/usr/sbin/control start $1 --key=$2" "CONTAINER_START_OK"
-	#sleep 2
 	do_wait_running "$1"
-	#sleep 2
 }
 
 cmd_control_start_error_unpaired() {
 	do_test_cmd_output "/usr/sbin/control start $1 --key=$2" "CONTAINER_START_TOKEN_UNPAIRED"
-	#sleep 2
-
 }
 
 cmd_control_start_error_eexist() {
 	do_test_cmd_output "/usr/sbin/control start $1 --key=$2" "CONTAINER_START_EEXIST"
-	#sleep 2
 }
-
-
 
 cmd_control_stop() {
 	do_test_cmd_output "/usr/sbin/control stop $1 --key=$2" "CONTAINER_STOP_OK"
 	do_wait_stopped "$1"
-	#sleep 2
-
 }
 
 cmd_control_stop_error_notrunning() {
 	do_test_cmd_output "/usr/sbin/control stop $1 --key=$2" "CONTAINER_STOP_FAILED_NOT_RUNNING"
 	do_wait_stopped "$1"
-	#sleep 2
-
 }
-
-
 
 cmd_control_list() {
 	do_test_cmd_output "/usr/sbin/control list" "code: CONTAINER_STATUS"
@@ -152,31 +93,25 @@ cmd_control_list_ncontainer() {
 	do_test_cmd_noutput "/usr/sbin/control list" "$1"
 }
 
-
 cmd_control_list_guestos() {
 	do_test_cmd_output "/usr/sbin/control list_guestos" "$1"
 }
 
 cmd_control_create() {
-if [ -z "$2" ];then
-	do_test_cmd_output "/usr/sbin/control create \"$1\"" "guest_os"
-else
-	do_test_cmd_output "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "guest_os"
-fi
-
-#sleep 5
+	if [[ -z "${2:-}" ]]; then
+		do_test_cmd_output "/usr/sbin/control create \"$1\"" "guest_os"
+	else
+		do_test_cmd_output "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "guest_os"
+	fi
 }
 
 cmd_control_create_error() {
-if [ -z "$2" ];then
-	do_test_cmd_noutput "/usr/sbin/control create \"$1\"" "uuids"
-else
-	do_test_cmd_noutput "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "uuids"
-fi
-
-#sleep 5
+	if [[ -z "${2:-}" ]]; then
+		do_test_cmd_noutput "/usr/sbin/control create \"$1\"" "uuids"
+	else
+		do_test_cmd_noutput "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "uuids"
+	fi
 }
-
 
 cmd_control_change_pin() {
 	do_test_cmd_output "echo -ne \"$2\n$3\n$3\n\" | /usr/sbin/control change_pin $1" "CONTAINER_CHANGE_PIN_SUCCESSFUL"
@@ -185,8 +120,6 @@ cmd_control_change_pin() {
 cmd_control_change_pin_error() {
 	do_test_cmd_output "echo -ne \"$2\n$3\n$3\n\" | /usr/sbin/control change_pin $1" "CONTAINER_CHANGE_PIN_FAILED"
 }
-
-
 
 cmd_control_config() {
 	do_test_cmd_output "/usr/sbin/control config $1" "$1"
@@ -197,7 +130,7 @@ cmd_control_remove() {
 }
 
 cmd_control_remove_error_eexist() {
-	do_test_cmd_output "/usr/sbin/control remove $1 --key=$2" "Container with provided uuid/name does not exist!"
+	do_test_cmd_output "/usr/sbin/control remove $1 --key=${2:-}" "Container with provided uuid/name does not exist!"
 }
 
 cmd_control_ca_register() {
@@ -210,8 +143,8 @@ cmd_control_reboot() {
 
 cmd_control_get_guestos_version(){
 	CMD="/usr/sbin/control list_guestos | grep $1 -A 2 | grep version\: | awk '{print \$2}' | sort | tail -n 1"
-	OUTPUT="$(ssh ${SSH_OPTS} "$CMD")"
-	echo $OUTPUT
+	OUTPUT="$(ssh "${SSH_OPTS[@]}" "$CMD")"
+	echo "$OUTPUT"
 }
 
 cmd_control_retrieve_logs() {
@@ -227,21 +160,15 @@ cmd_control_set_provisioned() {
 }
 
 cmd_control_list_guestos_silent() {
-    OUTPUT="$(ssh ${SSH_OPTS} "/usr/sbin/control list_guestos" 2>&1)" || true
-    dbg "Command returned $OUTPUT, code: $?"
-
-    if ! echo_status "$OUTPUT" | grep -q "$1";then
-        dbg "exitcode: $?"
-        echo_error "Check failed, expected \"$2\", got:"
-        echo_error "\"$OUTPUT\""
-        exit 1
-    fi 
+    OUTPUT="$(ssh "${SSH_OPTS[@]}" "/usr/sbin/control list_guestos" 2>&1)" || true
+    if ! echo "$OUTPUT" | grep -q "$1"; then
+        die "Expected \"$1\" in list_guestos output"
+    fi
 }
 
 cmd_control_update_config() {
 	do_test_cmd_output "/usr/sbin/control update_config $1" "$2"
 }
-
 
 cmd_control_push_guestos_config() {
 	do_test_cmd_output "/usr/sbin/control push_guestos_config $1" "response: $2"
@@ -249,8 +176,8 @@ cmd_control_push_guestos_config() {
 
 cmd_control_get_uuid() {
 	CMD="/usr/sbin/control state $1 | grep uuid\: | awk -F '\"' '{print \$2}'"
-	OUTPUT="$(ssh ${SSH_OPTS} "$CMD")"
-	echo $OUTPUT
+	OUTPUT="$(ssh "${SSH_OPTS[@]}" "$CMD")"
+	echo "$OUTPUT"
 }
 
 cmd_control_state_is_running() {

--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -1,28 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -e
-
-STAGE="PREPARING"
-
-echo_status () {
-    echo "$(date --rfc-3339=ns) [${STAGE}] STATUS: $1"
-}
-echo_error () {
-    echo "$(date --rfc-3339=ns) [${STAGE}] ERROR:  $1"
-}
-
-CMDPATH="${BASH_SOURCE[0]}"
-echo_status "Sourcing $(dirname "${CMDPATH}")/settings.sh"
-source "$(dirname "${CMDPATH}")/settings.sh"
-
-echo_status "Sourcing $(dirname "${CMDPATH}")/VM-container-commands.sh"
-source "$(dirname "${CMDPATH}")/VM-container-commands.sh"
-
-echo_status "Sourcing $(dirname "${CMDPATH}")/VM-management.sh"
-source "$(dirname "${CMDPATH}")/VM-management.sh"
-
-echo_status "Sourcing $(dirname "${CMDPATH}")/testdata.sh"
-source "$(dirname "${CMDPATH}")/testdata.sh"
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
+source "${RUNDIR}/settings.sh"
+source "${RUNDIR}/VM-container-commands.sh"
+source "${RUNDIR}/VM-management.sh"
+source "${RUNDIR}/testdata.sh"
 
 OPT_FORCE_SIG_CFGS="n"
 
@@ -30,204 +15,149 @@ OPT_FORCE_SIG_CFGS="n"
 # ----------------------------------------------
 
 do_copy_update_configs(){
-# Copy test guestos configs for update to VM
+local -a FILES=(
+	nullos-1.conf nullos-1.sig nullos-1.cert
+	nullos-2.conf nullos-2.sig nullos-2.cert
+	nullos-3.conf nullos-3.sig nullos-3.cert
+)
 for I in $(seq 1 10) ;do
-	echo_status "Trying to copy GuestOS configs to image"
-
-	FILES=" nullos-1.conf nullos-1.sig nullos-1.cert \
-		nullos-2.conf nullos-2.sig nullos-2.cert \
-		nullos-3.conf nullos-3.sig nullos-3.cert"
-
-	if scp $SCP_OPTS $FILES root@127.0.0.1:/tmp/;then
-		echo_status "scp was successful"
+	if scp "${SCP_OPTS[@]}" "${FILES[@]}" root@127.0.0.1:/tmp/; then
 		break
-	elif ! [ $I -eq 10 ];then
-		echo_status "scp failed, retrying..."
-	else
-		echo_status "Failed to copy nullos GuestOS configs to VM, exiting..."
+	elif [[ "$I" -eq 10 ]]; then
+		eerror "Failed to copy GuestOS configs to VM after 10 attempts"
 		err_fetch_logs
 	fi
+	sleep 0.5
 done
 }
 
 do_copy_kernel_update(){
-KERNEL_VERSION=$1
-# Copy test kernel config for update to VM
+local KERNEL_VERSION="$1"
+local -a FILES=(
+	"kernel-${KERNEL_VERSION}.conf"
+	"kernel-${KERNEL_VERSION}.sig"
+	"kernel-${KERNEL_VERSION}.cert"
+	"kernel-${KERNEL_VERSION}"
+)
 for I in $(seq 1 10) ;do
-	echo_status "Trying to copy kernel config to image"
-
-	FILES=" kernel-$KERNEL_VERSION.conf \
-					kernel-$KERNEL_VERSION.sig \
-					kernel-$KERNEL_VERSION.cert \
-					kernel-$KERNEL_VERSION"
-
-	if scp -r $SCP_OPTS $FILES root@127.0.0.1:/tmp/;then
-		echo_status "scp was successful"
+	if scp -r "${SCP_OPTS[@]}" "${FILES[@]}" root@127.0.0.1:/tmp/; then
 		break
-	elif ! [ $I -eq 10 ];then
-		echo_status "scp failed, retrying..."
-	else
-		echo_status "Failed to copy kernel GuestOS configs to VM, exiting..."
+	elif [[ "$I" -eq 10 ]]; then
+		eerror "Failed to copy kernel configs to VM after 10 attempts"
 		err_fetch_logs
 	fi
+	sleep 0.5
 done
 }
 
 do_test_rm() {
-	CONTAINER="$1"
-
-	echo_status "Change pin: (set pin) -> $TESTPW token PIN"
+	local CONTAINER="$1"
+	einfo "Test: remove running container ${CONTAINER}"
 	cmd_control_change_pin "${CONTAINER}" "" "$TESTPW"
-
-	echo_status "Starting container \"${CONTAINER}\""
 	cmd_control_start "${CONTAINER}" "$TESTPW"
-
-	# Test container removal of running container
-	echo_status "Removing container \"${CONTAINER}\""
 	cmd_control_remove "${CONTAINER}" "$TESTPW"
 }
 
 do_test_complete() {
-	CONTAINER="$1"
-	SECOND_RUN="$2"
-	USBTOKEN="$3"
-	echo_status "########## Starting container test suite, CONTAINER=${CONTAINER}, SECOND_RUN=${SECOND_RUN}, USBTOKEN=${USBTOKEN} ##########"
+	local CONTAINER="$1"
+	local SECOND_RUN="$2"
+	local USBTOKEN="$3"
+	begin "Test suite: ${CONTAINER} (run=${SECOND_RUN}, usb=${USBTOKEN})"
 
-	# Test if cmld is up and running
-	echo_status "Test if cmld is up and running"
 	cmd_control_list
 
-	if [ "n" = "$USBTOKEN" ];then
-		# Skip these tests for physical schsm
-		if ! [ "${SECOND_RUN}" = "y" ];then
-			echo_status "Trigger ERROR_UNPAIRED"
+	if [[ "n" == "$USBTOKEN" ]]; then
+		if [[ "${SECOND_RUN}" != "y" ]]; then
+			elog "Verify unpaired start fails"
 			cmd_control_start_error_unpaired "${CONTAINER}" "$TESTPW"
-
-			echo_status "Change pin: (set pin) -> $TESTPW token PIN"
 			cmd_control_change_pin "${CONTAINER}" "" "$TESTPW"
-
 		else
-			echo_status "Re-changing token PIN"
 			cmd_control_change_pin "${CONTAINER}" "$TESTPW" "$TESTPW"
 		fi
-
+		elog "Verify wrong PIN fails"
 		cmd_control_change_pin_error "${CONTAINER}" "wrongpin" "$TESTPW"
-	else
-		# TODO add --schsm-all flag
-		echo_status "Skipping change_pin test for sc-hsm"
 	fi
 
-	echo_status "Starting container \"${CONTAINER}\""
+	elog "Start/stop/config lifecycle"
 	cmd_control_start "${CONTAINER}" "$TESTPW"
-
 	cmd_control_config "${CONTAINER}"
 
-	ssh ${SSH_OPTS} "echo testmessage1 > /dev/fifos/signedfifo1"
-
-	ssh ${SSH_OPTS} "echo testmessage2 > /dev/fifos/signedfifo2"
+	ssh "${SSH_OPTS[@]}" "echo testmessage1 > /dev/fifos/signedfifo1"
+	ssh "${SSH_OPTS[@]}" "echo testmessage2 > /dev/fifos/signedfifo2"
 
 	cmd_control_list_guestos "gyroidos-coreos"
-
 	cmd_control_remove_error_eexist "nonexistent-container"
-
 	cmd_control_start_error_eexist "${CONTAINER}" "$TESTPW"
 
-
-	# Stop test container
 	cmd_control_stop "${CONTAINER}" "$TESTPW"
-
 	cmd_control_stop_error_notrunning "${CONTAINER}" "$TESTPW"
 
 	# Perform extended update test (triggers reload)
 	if [[ -f "${CONTAINER}_rename.conf" ]]; then
-		# get uuid since name is changed during update
+		elog "Config update/reload test"
+		local uuid
 		uuid=$(cmd_control_get_uuid "${CONTAINER}")
 
-		# direct reload
 		cmd_control_update_config "${uuid} /tmp/${CONTAINER}_rename.conf /tmp/${CONTAINER}_rename.sig /tmp/${CONTAINER}_rename.cert" "name: \"${CONTAINER}-rename\""
-
-		# check if reload worked by starting with new name
 		cmd_control_start "${CONTAINER}-rename" "$TESTPW"
-
-		# indirect reload, trigger internal out-of-sync state
 		cmd_control_update_config "${uuid} /tmp/${CONTAINER}_update.conf /tmp/${CONTAINER}_update.sig /tmp/${CONTAINER}_update.cert" "name: \"${CONTAINER}\""
-
-		# trigger reload
 		cmd_control_stop "${uuid}" "$TESTPW"
-
-		# check if reload worked by starting with old name
 		cmd_control_start "${CONTAINER}" "$TESTPW"
-
 		cmd_control_stop "${CONTAINER}" "$TESTPW"
 	fi
-	#
-	# Perform additional tests in second run
-	if [[ "${SECOND_RUN}" == "y" ]];then
 
-		# test start / stop cycles
-		for I in {1..100};do
-			echo_status "Start/stop cycle $I"
-
+	if [[ "${SECOND_RUN}" == "y" ]]; then
+		einfo "Start/stop stress test (100 cycles)"
+		for I in {1..100}; do
 			cmd_control_start "${CONTAINER}" "$TESTPW"
-
 			cmd_control_stop "${CONTAINER}" "$TESTPW"
 		done
 
-
-		# test retrieve_logs command
-		TMPDIR="$(ssh ${SSH_OPTS} "mktemp -d -p /tmp")"
-
-		if [[ "ccmode" == "${MODE}" ]] && ! [[ "y" == "${OPT_CC_MODE_EXPERIMENTAL}" ]];then
+		elog "Retrieve logs"
+		local TMPDIR
+		TMPDIR="$(ssh "${SSH_OPTS[@]}" "mktemp -d -p /tmp")"
+		if [[ "ccmode" == "${MODE}" ]] && [[ "y" != "${OPT_CC_MODE_EXPERIMENTAL}" ]]; then
 			cmd_control_retrieve_logs "${TMPDIR}" "CMD_UNSUPPORTED"
 		else
 			cmd_control_retrieve_logs "${TMPDIR}" "CMD_OK"
 		fi
 
-		# Test container removal
-		echo_status "Second test run, removing container"
+		elog "Remove container and verify"
 		cmd_control_remove "${CONTAINER}" "$TESTPW"
-
-		echo_status "Check container has been removed"
 		cmd_control_list_ncontainer "${CONTAINER}"
-
-		echo_status "Removing non-existent container"
 		cmd_control_remove_error_eexist "${CONTAINER}" "$TESTPW"
 	fi
 
+	ok "Test suite: ${CONTAINER}"
 }
 
 do_test_provisioning() {
-	echo_status "########## Starting device provisioning test suite ##########"
-	# test provisioning always last since set_provisioned reduces the command set
-
-	echo_status "Check that device is not provisioned yet"
+	begin "Test: device provisioning"
 	cmd_control_get_provisioned false
-
-	echo_status "Setting device to provisioned state"
 	cmd_control_set_provisioned "CMD_OK"
-
-	echo_status "Check that device is provisioned"
 	cmd_control_get_provisioned true
-
-	echo_status "Check device reduced command set"
 	cmd_control_set_provisioned "CMD_UNSUPPORTED"
+	ok "Test: device provisioning"
 }
 
 do_test_update() {
-	GUESTOS_NAME="$1"
-	GUESTOS_VERSION="$2"
+	local GUESTOS_NAME="$1"
+	local GUESTOS_VERSION="$2"
+	local image_size_by_os_version=$(( GUESTOS_VERSION * 1024 ))
+	local os_path="/${update_base_url}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}"
+	local conf_args="/tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.conf /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.sig /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.cert"
 
 	local update_path="/${update_base_url#/}/operatingsystems/x86/${GUESTOS_NAME}-${GUESTOS_VERSION}"
-	echo_status "########## Starting guestos update test suite, GUESTOS=${GUESTOS_NAME}, VERSION=${GUESTOS_VERSION} ##########"
+	einfo "########## Starting guestos update test suite, GUESTOS=${GUESTOS_NAME}, VERSION=${GUESTOS_VERSION} ##########"
 
 	ssh ${SSH_OPTS} "mkdir -p '${update_path}'"
 	cmd_control_push_guestos_config "/tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.conf /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.sig /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.cert" "GUESTOS_MGR_INSTALL_FAILED"
 
 	ssh ${SSH_OPTS} "truncate -s '${GUESTOS_VERSION}G' '${update_path}/root.img'"
-	echo_status "ssh ${SSH_OPTS} \"truncate -s '${GUESTOS_VERSION}G' '${update_path}/root.img'\""
+	einfo "ssh ${SSH_OPTS} \"truncate -s '${GUESTOS_VERSION}G' '${update_path}/root.img'\""
 	ssh ${SSH_OPTS} "truncate -s '${GUESTOS_VERSION}M' '${update_path}/root.hash.img'"
 
-	echo_status "ssh ${SSH_OPTS} \"ls -lh '${update_path}'\""
+	einfo "ssh ${SSH_OPTS} \"ls -lh '${update_path}'\""
 	ssh ${SSH_OPTS} "ls -lh '${update_path}'"
 
 	cmd_control_push_guestos_config "/tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.conf /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.sig /tmp/${GUESTOS_NAME}-${GUESTOS_VERSION}.cert" "GUESTOS_MGR_INSTALL_COMPLETED"
@@ -236,120 +166,104 @@ do_test_update() {
 }
 
 do_test_push_kernel_update() {
-	# obtain the guestos verion of the current kernel, should match the installed one
+	local KERNEL_VERSION
 	KERNEL_VERSION=$(gawk 'match($0, /^version: (.*)/, ary) {print ary[1]}' kernel/kernel-*.conf)
-	KERNEL_VERSION_NEW=$(($KERNEL_VERSION + 1))
+	local KERNEL_VERSION_NEW=$(( KERNEL_VERSION + 1 ))
 
-	echo_status "########## Starting kernel update test suite, GUESTOS=${GUESTOS_NAME}, VERSION_UPDATE: ${KERNEL_VERSION} -> ${KERNEL_VERSION_NEW}  ##########"
-	do_copy_kernel_update $KERNEL_VERSION_NEW
-	ssh ${SSH_OPTS} "mkdir -p /${update_base_url}/operatingsystems/x86"
-	ssh ${SSH_OPTS} "mv /tmp/kernel-${KERNEL_VERSION_NEW} /${update_base_url}/operatingsystems/x86"
+	begin "Test: kernel update ${KERNEL_VERSION} -> ${KERNEL_VERSION_NEW}"
+	do_copy_kernel_update "$KERNEL_VERSION_NEW"
+	ssh "${SSH_OPTS[@]}" "mkdir -p /${update_base_url}/operatingsystems/x86"
+	ssh "${SSH_OPTS[@]}" "mv /tmp/kernel-${KERNEL_VERSION_NEW} /${update_base_url}/operatingsystems/x86"
 	cmd_control_push_guestos_config "/tmp/kernel-${KERNEL_VERSION_NEW}.conf /tmp/kernel-${KERNEL_VERSION_NEW}.sig /tmp/kernel-${KERNEL_VERSION_NEW}.cert" "GUESTOS_MGR_INSTALL_COMPLETED"
 
-	#ssh ${SSH_OPTS} "rm -r /${update_base_url}/operatingsystems/x86/kernel-${KERNEL_VERSION}"
-
-	# after successful kernel update both versions must be installed
 	cmd_control_list_guestos "${KERNEL_VERSION}"
 	cmd_control_list_guestos "${KERNEL_VERSION_NEW}"
+	ok "Test: kernel update"
 }
 
 do_test_check_kernel_version() {
-	# obtain the guestos verion of the current kernel, should match the installed one
+	local KERNEL_VERSION
 	KERNEL_VERSION=$(gawk 'match($0, /^version: (.*)/, ary) {print ary[1]}' kernel/kernel-*.conf)
-	KERNEL_VERSION_NEW=$(($KERNEL_VERSION + 1))
+	local KERNEL_VERSION_NEW=$(( KERNEL_VERSION + 1 ))
 
-	# after reboot, still both versions must be installed
+	einfo "Verify kernel versions ${KERNEL_VERSION} and ${KERNEL_VERSION_NEW} present after reboot"
 	cmd_control_list_guestos "${KERNEL_VERSION}"
 	cmd_control_list_guestos "${KERNEL_VERSION_NEW}"
 
-	# check the logs to ensure B boot option was started after update
-	if [[ "ccmode" != "${MODE}" ]] || [[ "y" == "${OPT_CC_MODE_EXPERIMENTAL}" ]];then
-		TMPDIR=$(ssh ${SSH_OPTS} "mktemp -d -p /tmp")
+	if [[ "ccmode" != "${MODE}" ]] || [[ "y" == "${OPT_CC_MODE_EXPERIMENTAL}" ]]; then
+		elog "Checking device.conf.B in cml-daemon log"
+		local TMPDIR
+		TMPDIR=$(ssh "${SSH_OPTS[@]}" "mktemp -d -p /tmp")
 		cmd_control_retrieve_logs "${TMPDIR}" "CMD_OK"
-		LATEST_LOG=$(ssh ${SSH_OPTS} "ls ${TMPDIR}/cml-daemon* | tail -n1")
-		echo_status "latest log: ${LATEST_LOG}"
-		# 'device.conf path is /data/cml/device.conf.B' appears in every build's log
-		GREP_OUT=$(ssh ${SSH_OPTS} "grep 'device.conf path is /data/cml/device.conf.B' ${LATEST_LOG}")
-		echo_status "grep output: ${GREP_OUT}"
+		local LATEST_LOG
+		LATEST_LOG=$(ssh "${SSH_OPTS[@]}" "ls ${TMPDIR}/cml-daemon* | tail -n1")
+		local GREP_OUT
+		GREP_OUT=$(ssh "${SSH_OPTS[@]}" "grep 'device.conf path is /data/cml/device.conf.B' ${LATEST_LOG}") || true
 		if [[ -z "${GREP_OUT}" ]]; then
-			echo_status "cmld did not load expected config. kernel update failed."
-			exit 1
+			die "cmld did not load device.conf.B — kernel update failed"
 		fi
 	fi
 }
 
-# Parse CLI arguments
-# -----------------------------------------------
-parse_cli $@
+# =====================================================================
+# Main
+# =====================================================================
+parse_cli "$@"
 
 # Compile project
-# -----------------------------------------------
-if [[ $COMPILE == true ]]
-then
-	# changes dir to BUILD_DIR
-	source init_ws.sh ${BUILD_DIR} x86 genericx86-64
+if [[ "$COMPILE" == true ]]; then
+	begin "Compile"
+	# oe-init-build-env (sourced transitively) doesn't tolerate nounset
+	set +u
+	# shellcheck disable=SC1091
+	source init_ws.sh "${BUILD_DIR}" x86 genericx86-64
+	set -u
 
-	if [[ $FORCE == true ]]
-	then
+	if [[ "$FORCE" == true ]]; then
 		bitbake -c clean multiconfig:container:gyroidos-core
 		bitbake -c clean cmld
 		bitbake -c clean gyroidos-cml-initramfs
 		bitbake -c clean gyroidos-cml
 	fi
 
-	if [[ $BRANCH != "" ]]
-	then
-		# TODO \${BRANCH} is defined in init_ws.sh -> if changes there, this won't work
+	if [[ -n "$BRANCH" ]]; then
 		sed -i "s/branch=\${BRANCH}/branch=$BRANCH/g" cmld_git.bbappend
 	fi
 
 	bitbake multiconfig:container:gyroidos-core
 	bitbake gyroidos-cml
-elif [[ -z "${IMGPATH}" ]]
-then
-	if [ ! -d "${BUILD_DIR}" ]
-	then
-		echo_error "Could not find build directory at \"${BUILD_DIR}\". Specify --build-dir or --img."
-		exit 1
-	fi
-
-	cd ${BUILD_DIR}
-	echo_status "Changed dir to ${BUILD_DIR}"
+	ok "Compile"
+elif [[ -z "${IMGPATH}" ]]; then
+	[[ -d "${BUILD_DIR}" ]] || die "Build directory not found: ${BUILD_DIR}"
+	cd "${BUILD_DIR}"  # intentional: subsequent operations run relative to BUILD_DIR
 fi
 
-# Check if the branch matches the built one
-if [[ $BRANCH != "" ]]
-then
-	# Check if cmld was build
-	if [ -z $(ls -d tmp/work/core*/cmld/git*/git) ]
-	then
-		echo_error "No cmld build found: did you compile?"
-		exit 1
-	fi
-
-
-	BUILD_BRANCH=$(git -C tmp/work/core*/cmld/git*/git branch | tee /proc/self/fd/1 | grep '*' | awk '{ print $NF }')  # check if git repo found and correct branch used
-	if [[ $BRANCH != $BUILD_BRANCH ]]
-	then
-		echo_error "The specified branch \"$BRANCH\" does not match the build ($BUILD_BRANCH). Please recompile with flag -c."
-		exit 1
-	fi
+if [[ -n "$BRANCH" ]]; then
+	# shellcheck disable=SC2012
+	[[ -n "$(ls -d tmp/work/core*/cmld/git*/git 2>/dev/null || true)" ]] || die "No cmld build found"
+	BUILD_BRANCH=$(git -C tmp/work/core*/cmld/git*/git branch | tee /proc/self/fd/1 | grep '\*' | awk '{ print $NF }')
+	[[ "$BRANCH" == "$BUILD_BRANCH" ]] || die "Branch mismatch: expected \"$BRANCH\", built \"$BUILD_BRANCH\""
 fi
 
-# Ensure VM is not running
-# -----------------------------------------------
-echo_status "Ensure VM is not running"
-if [[ $(pgrep $PROCESS_NAME) != "" ]]
-then
-	if [ ${KILL_VM} ];then
-		echo_status "Kill current VM (--kill was given)"
-		pgrep ${PROCESS_NAME} | xargs kill -SIGKILL
+if [[ -n "$(pgrep "$PROCESS_NAME" || true)" ]]; then
+	[[ "$KILL_VM" == true ]] || die "VM \"$PROCESS_NAME\" already running"
+	pgrep "${PROCESS_NAME}" | xargs kill -SIGKILL
+fi
+
+# Prepare images
+begin "Prepare test images"
+if ! [[ -e "${PROCESS_NAME}.ext4fs" ]]; then
+	dd if=/dev/zero of="${PROCESS_NAME}.ext4fs" bs=1M count=10000 &> /dev/null
+fi
+mkfs.ext4 -L containers "${PROCESS_NAME}.ext4fs"
+rm -f "${PROCESS_NAME}.img"
+
+if [[ -n "${IMGPATH}" ]]; then
+	einfo "Image: ${IMGPATH}"
+	rsync "${IMGPATH}" "${PROCESS_NAME}.img"
 else
-		echo_error "VM instance called \"$PROCESS_NAME\" already running. Please stop/kill it first."
-		exit 1
-fi
-else
-	echo_status "VM not running"
+	einfo "Image: $(pwd)/tmp/deploy/images/genericx86-64/gyroidos_image/gyroidosimage.img"
+	rsync tmp/deploy/images/genericx86-64/gyroidos_image/gyroidosimage.img "${PROCESS_NAME}.img"
 fi
 
 # Create image
@@ -377,195 +291,118 @@ else
 fi
 
 # Prepare image for test with physical tokens
-if ! [[ -z "${HSM_SERIAL}" ]]
-then
-	echo_status "Preparing image for test with hsm container"
+if [[ -n "${HSM_SERIAL}" ]]; then
+	einfo "Preparing HSM image (serial=${HSM_SERIAL})"
 	/usr/local/bin/preparetmeimg.sh "$(pwd)/${PROCESS_NAME}.img"
 fi
 
-# Start VM
-# -----------------------------------------------
-
-# copy for faster startup
-if [ -f "/usr/share/OVMF/OVMF_VARS.fd" ];then
+if [[ -f "/usr/share/OVMF/OVMF_VARS.fd" ]]; then
 	cp /usr/share/OVMF/OVMF_VARS.fd OVMF_VARS.fd
-elif [ -f "/usr/share/OVMF/OVMF_VARS_4M.fd" ];then
+elif [[ -f "/usr/share/OVMF/OVMF_VARS_4M.fd" ]]; then
 	cp /usr/share/OVMF/OVMF_VARS_4M.fd OVMF_VARS.fd
 else
-	echo_error "Failed to locate OVMF_VARS"
-	exit 1
+	die "Failed to locate OVMF_VARS"
 fi
+ok "Prepare test images"
 
-STAGE="BOOT1"
-# Start test VM
+# Boot 1 — initial boot & host key
+begin "Boot 1"
 start_vm
-STAGE="RUN1"
 
-
-# Retrieve VM host key
-echo_status "Retrieving VM host key"
 for I in $(seq 1 10) ;do
-	echo_status "Scanning for VM host key on port $SSH_PORT"
-	if ssh-keyscan -T 10 -p $SSH_PORT -H 127.0.0.1 > ${PROCESS_NAME}.vm_key ;then
-		echo_status "Got VM host key: $!"
+	if ssh-keyscan -T 10 -p "$SSH_PORT" -H 127.0.0.1 > "${PROCESS_NAME}.vm_key" 2>/dev/null; then
 		break
-	elif [ "10" = "$I" ];then
-		echo_error "exitcode $1"
-		exit 1
+	elif [[ "10" == "$I" ]]; then
+		die "Failed to retrieve VM host key"
 	fi
-
-	echo_status "Failed to retrieve VM host key"
 done
 
-echo_status "extracting current installed OS version"
 installed_guestos_version="$(cmd_control_get_guestos_version gyroidos-coreos)"
-echo_status "Found OS version: $installed_guestos_version"
+einfo "GuestOS version: $installed_guestos_version"
 
 update_base_url="var/volatile/tmp"
+ok "Boot 1"
 
-# Prepare tests
-# -----------------------------------------------
-echo_status "########## Preparing tests ##########"
-
+# Prepare test configs & containers
+begin "Create test configs and containers"
 do_create_testconfigs
-
 do_copy_configs
 
-# Prepare test container
-# -----------------------------------------------
-
-
-echo_status "########## Setting up test containers ##########"
-# Test if cmld is up and running
-echo_status "Test if cmld is up and running"
 cmd_control_list
 
-# Skip root CA registering test if test PKI no available or disabled
-if [[ "$COPY_ROOTCA" == "y" ]]
-then
-	echo_status "Copying root CA at ${PKI_DIR}/ssig_rootca.cert to image as requested"
+if [[ "$COPY_ROOTCA" == "y" ]]; then
+	elog "Copying root CA to VM"
 	for I in $(seq 1 10) ;do
-		echo_status "Trying to copy rootca cert"
-		if scp -q $SCP_OPTS ${PKI_DIR}/ssig_rootca.cert root@127.0.0.1:/tmp/;then
-			echo_status "scp was sucessful"
+		if scp -q "${SCP_OPTS[@]}" "${PKI_DIR}/ssig_rootca.cert" root@127.0.0.1:/tmp/; then
 			break
-		elif ! [ $I -eq 10 ];then
-			echo_status "Failed to copy root CA, retrying..."
-			sleep 0.5
-		else
-			echo_error "Could not copy root CA to VM, exiting..."
-			exit 1
+		elif [[ "$I" -eq 10 ]]; then
+			die "Could not copy root CA to VM"
 		fi
+		sleep 0.5
 	done
-
-
 	cmd_control_ca_register " /tmp/ssig_rootca.cert"
 fi
 
-echo_status "Updating c0.conf"
 cmd_control_update_config "core0 /tmp/c0.conf /tmp/c0.sig /tmp/c0.cert" "allow_dev: \"b 8:"
 cmd_control_config "core0"
 
-# Create test containers
-echo_status "OPT_FORCE_SIG_CFGS: $OPT_FORCE_SIG_CFGS"
-if [ "dev" = "$MODE" ] && [ "n" = "$OPT_FORCE_SIG_CFGS" ];then
-	echo_status "Creating unsigned test container, expecting success:\n$(cat testcontainer.conf)"
+elog "Creating containers (mode=${MODE}, force_sig=${OPT_FORCE_SIG_CFGS})"
+if [[ "dev" == "$MODE" ]] && [[ "n" == "$OPT_FORCE_SIG_CFGS" ]]; then
 	cmd_control_create "/tmp/testcontainer.conf"
 	cmd_control_list_container "testcontainer"
 else
-	echo_status "Creating unsigned test container, expecting error:\n$(cat testcontainer.conf)"
 	cmd_control_create_error "/tmp/testcontainer.conf"
 fi
 
-echo_status "Creating signed container:\n$(cat signedcontainer1.conf)"
 cmd_control_create "/tmp/signedcontainer1.conf" "/tmp/signedcontainer1.sig" "/tmp/signedcontainer1.cert"
 cmd_control_list_container "signedcontainer1"
 
-
-if [[ -z "${HSM_SERIAL}" ]];then
-	echo_status "Creating signed container:\n$(cat signedcontainer2.conf)"
+if [[ -z "${HSM_SERIAL}" ]]; then
 	cmd_control_create "/tmp/signedcontainer2.conf" "/tmp/signedcontainer2.sig" "/tmp/signedcontainer2.cert"
 	cmd_control_list_container "signedcontainer2"
 fi
 
-echo_status "Creating rmcontainer:\n$(cat rmcontainer3.conf)"
 cmd_control_create "/tmp/rmcontainer3.conf" "/tmp/rmcontainer3.sig" "/tmp/rmcontainer3.cert"
 cmd_control_list_container "rmcontainer3"
+ok "Create test configs and containers"
 
 sync_to_disk
-
 sync_to_disk
 
-
-STAGE="BOOT2"
+# Boot 2 — reboot and verify persistence
+begin "Boot 2"
 cmd_control_reboot
 wait_vm
-STAGE="RUN2"
-
-# List test containers
-if [ "dev" = "$MODE" ] && [ "n" = "$OPT_FORCE_SIG_CFGS" ];then
-	cmd_control_list_container "testcontainer"
-fi
 
 cmd_control_list_container "signedcontainer1"
-
-if [[ -z "${HSM_SERIAL}" ]];then
-	cmd_control_list_container "signedcontainer2"
-fi
-
 do_copy_configs
 
-echo_status "Updating signedcontainer1"
-
 cmd_control_update_config "signedcontainer1 /tmp/signedcontainer1_update.conf /tmp/signedcontainer1_update.sig /tmp/signedcontainer1_update.cert" "netif: \"00:00:00:00:00:11\""
-# Workaround to avoid issues qith QEMU's forwarding rules
-#sleep 5
 
-# Set device container pairing state if testing with physical tokens
-if ! [[ -z "${HSM_SERIAL}" ]];then
-	STAGE="SE_PREPARE"
-	echo_status "########## Preparing SE ##########"
-
+if [[ -n "${HSM_SERIAL}" ]]; then
+	einfo "Preparing SE pairing"
 	sync_to_disk
 	sync_to_disk
-
 	force_stop_vm
 
-	echo_status "Setting container pairing state"
 	/usr/local/bin/preparetmecontainer.sh "$(pwd)/${PROCESS_NAME}.ext4fs"
-
-	echo_status "Waiting for QEMU to cleanup USB devices"
 	sleep 2
 
 	start_vm
-	echo_status "Waiting for USB devices to become ready in QEMU"
 	sleep 2
-	echo_status "VM USB Devices:"
-	ssh ${SSH_OPTS} 'lsusb' 2>&1
-	STAGE="RUN2"
-
 	do_copy_configs
 fi
 
-# List test containers
-if [ "dev" = "$MODE" ] && [ "n" = "$OPT_FORCE_SIG_CFGS" ];then
-	cmd_control_list_container "testcontainer"
-fi
-
 cmd_control_list_container "signedcontainer1"
-
-if [[ -z "${HSM_SERIAL}" ]];then
+if [[ -z "${HSM_SERIAL}" ]]; then
 	cmd_control_list_container "signedcontainer2"
 fi
-
 do_copy_update_configs
+ok "Boot 2"
 
-# Start tests
-# -----------------------------------------------
-
-echo_status "Starting tests"
-
-if [ -z "${HSM_SERIAL}" ];then
+# Run integration tests — first pass
+begin "Integration tests (pass 1)"
+if [[ -z "${HSM_SERIAL}" ]]; then
 	do_test_complete "signedcontainer1" "n" "n"
 	do_test_complete "signedcontainer2" "n" "n"
 else
@@ -573,25 +410,21 @@ else
 fi
 
 do_test_rm "rmcontainer3"
-
 do_test_update "nullos" "1"
 do_test_update "nullos" "2"
+ok "Integration tests (pass 1)"
 
-STAGE="BOOT3"
+# Boot 3 — reboot and second pass
+begin "Boot 3"
 cmd_control_reboot
-# Workaround to avoid issues qith QEMU's forwarding rules
-#sleep 5
 wait_vm
-STAGE="RUN3"
+ok "Boot 3"
 
 do_copy_configs
 do_copy_update_configs
 
-#echo_status "Waiting for USB devices to become ready in QEMU"
-#sleep 5
-#ssh ${SSH_OPTS} 'echo_status "VM USB Device: " && lsusb' 2>&1
-
-if [ -z "${HSM_SERIAL}" ];then
+begin "Integration tests (pass 2)"
+if [[ -z "${HSM_SERIAL}" ]]; then
 	do_test_complete "signedcontainer1" "y" "n"
 	do_test_complete "signedcontainer2" "y" "n"
 else
@@ -599,48 +432,39 @@ else
 fi
 
 do_test_update "nullos" "3"
-
 do_test_provisioning
-
 do_test_push_kernel_update
+ok "Integration tests (pass 2)"
 
-STAGE="BOOT4"
+# Boot 4 — verify kernel update
+begin "Boot 4"
 cmd_control_reboot
 wait_vm
-STAGE="RUN4"
+ok "Boot 4"
 
 do_test_check_kernel_version
 
-if [[ "production" == "${MODE}" ]];then
-	STAGE="PREPARE SWTPM"
+if [[ "production" == "${MODE}" ]]; then
+	begin "TPM2 test"
 	force_stop_vm
-
-	echo_status "Waiting for QEMU to cleanup"
 	sleep 2
-
-	# logs cannot be retrieved with fetch_logs after encryption
-	fetch_logs
-
-	echo_status "Starting swtpm"
+	fetch_logs  # must happen before encryption
 	start_swtpm
 
 	SWTPM="-chardev socket,id=chrtpm,path=/tmp/swtpmqemu/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
 	start_vm
 
-	STAGE="RUN5"
 	cmd_control_state_is_running "TPM2D"
+	ok "TPM2 test"
 fi
 
 # Success
-# -----------------------------------------------
-echo -e "\n\nSUCCESS: All tests passed"
-
 trap - EXIT
-
 force_stop_vm
 
-if [[ "production" != "${MODE}" ]];then
+if [[ "production" != "${MODE}" ]]; then
 	fetch_logs
 fi
 
+ok "All tests passed"
 exit 0

--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -1,39 +1,35 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 sync_to_disk() {
-    echo_status "Syncing VM state to disk"
-    for I in $(seq 1 10) ;do 
-        if ssh ${SSH_OPTS} 'sh -c sync && sleep 1' 2>&1;then
-            echo_status "Synced VM state to disk"
-            break
-        elif ! [[ "$I" == "10" ]];then
-            echo_status "Failed to sync VM state to disk, retrying"
-            sleep 0.5
-        else
-            echo_error "Could not sync VM state to disk, exiting..."
+    for I in $(seq 1 10) ;do
+        if ssh "${SSH_OPTS[@]}" 'sh -c sync && sleep 1' 2>&1; then
+            return
+        elif [[ "$I" == "10" ]]; then
+            eerror "Could not sync VM state to disk"
         fi
+        sleep 0.5
     done
 }
 
 force_stop_vm() {
+    elog "Stopping VM"
     sync_to_disk
-
     sleep 2
-    echo_status "Sending quit to QEMU monitor socket"
-    if echo "quit" | socat - ./${PROCESS_NAME}.qemumon;then
-        echo_status "Sucessfully requested VM to exit cleanly"
-    else
-        echo_status "Failed to request clean VM exit"
-    fi
-
-    rm -f ${PROCESS_NAME}.vm_key
+    printf 'quit\n' | socat -T2 STDIN "UNIX-CONNECT:./${PROCESS_NAME}.qemumon" || true
+    rm -f "${PROCESS_NAME}.vm_key"
 }
 
 fetch_logs() {
-    if [ -z "${LOG_DIR}" ];then
-        echo_status "-l / --log-dir not specified, skipping log file retrieval"
-    else
+    if [[ -z "${LOG_DIR}" ]]; then
+        return
+    fi
+    elog "Retrieving CML logs to ${LOG_DIR}"
+    {
         mkdir -p "${LOG_DIR}"
         local skip sectors sector_size fdisk_out
         fdisk_out="$(/sbin/fdisk -lu "${PROCESS_NAME}.img")"
@@ -56,19 +52,15 @@ fetch_logs() {
             if [ -z "${i##*.current}" ]; then
                 continue;
             fi
-            e2cp ${PROCESS_NAME}.data:/userdata/logs/${i} ${LOG_DIR}/
+            e2cp "${PROCESS_NAME}.data:/userdata/logs/${i}" "${LOG_DIR}/"
         done
-        echo_status "Retrieved CML logs: $(ls -al ${LOG_DIR})"
-    fi
+    }
 }
 
 err_fetch_logs() {
-    echo_status "An error occurred, attempting to fetch logs from VM"
-
+    eerror "An error occurred, attempting to fetch logs from VM"
     trap - EXIT INT TERM
-
     force_stop_vm
-
     fetch_logs
     exit 1
 }
@@ -77,34 +69,22 @@ err_fetch_logs() {
 trap 'err_fetch_logs' EXIT INT TERM
 
 wait_vm () {
-    echo_status "Waiting for VM to become available"
+    elog "Waiting for VM to become available"
     sleep 3
-    # Copy test container config to VM
-    success="n"
     for I in $(seq 1 100) ;do
         sleep 1
-
-        if [[ -z "$(pgrep $PROCESS_NAME)" ]];then
-            echo_status "Error: QEMU process exited"
-            exit 1
+        if [[ -z "$(pgrep "$PROCESS_NAME")" ]]; then
+            die "QEMU process exited unexpectedly"
         fi
-        if ssh -q ${SSH_OPTS} "ls /data" ;then
-            echo_status "VM access was successful"
-            success="y"
-            break
-        else
-            printf "."
+        if ssh -q "${SSH_OPTS[@]}" "ls /data" ; then
+            return
         fi
     done
-
-    if [[ "$success" != "y" ]];then
-        echo_status "VM access failed, exiting..."
-        exit 1
-    fi
+    die "VM not reachable after 100s"
 }
 
 start_swtpm() {
-    if [[ ! -d "/tmp/swtpmqemu" ]];then
+    if [[ ! -d "/tmp/swtpmqemu" ]]; then
 	    mkdir /tmp/swtpmqemu
     fi
 
@@ -113,38 +93,38 @@ start_swtpm() {
 
 # $1: Disk Image Path
 align_image () {
-    local img_path="$(realpath -e "$1")"
-    # Get mountpoint of hosting filesystem
-    local hosting_mount="$(df --output=target "$img_path" | tail -1)"
-    # Get filesystem block size
-    local fs_bsize="$(stat -fc%s "$hosting_mount" 2>/dev/null || echo 4096)"
-    # Resize to be a multiple of the fs block size
-    echo_status "Resizing ${1} to match fs block size of ${fs_bsize}B"
-    qemu-img resize -f raw "$img_path" $(( (($(stat -c%s "$img_path") + $fs_bsize - 1) / $fs_bsize) * $fs_bsize ))
+    local img_path
+    img_path="$(realpath -e "$1")"
+    local hosting_mount
+    hosting_mount="$(df --output=target "$img_path" | tail -1)"
+    local fs_bsize
+    fs_bsize="$(stat -fc%s "$hosting_mount" 2>/dev/null || echo 4096)"
+    qemu-img resize -f raw "$img_path" $(( (($(stat -c%s "$img_path") + fs_bsize - 1) / fs_bsize) * fs_bsize )) >/dev/null
 }
 
 start_vm() {
-	ovmf_code=""
-	if [ -f "/usr/share/OVMF/OVMF_CODE.fd" ];then
+	local ovmf_code=""
+	if [[ -f "/usr/share/OVMF/OVMF_CODE.fd" ]]; then
 		ovmf_code="/usr/share/OVMF/OVMF_CODE.fd"
-	elif [ -f "/usr/share/OVMF/OVMF_CODE_4M.fd" ];then
+	elif [[ -f "/usr/share/OVMF/OVMF_CODE_4M.fd" ]]; then
 		ovmf_code="/usr/share/OVMF/OVMF_CODE_4M.fd"
 	else
-		echo_error "Failed to locate OVMF_CODE"
-		exit 1
+		die "Failed to locate OVMF_CODE"
 	fi
 
+    elog "Starting QEMU VM (${PROCESS_NAME})"
     align_image "${PROCESS_NAME}.img"
     align_image "${PROCESS_NAME}.ext4fs"
+    # shellcheck disable=SC2086 # SWTPM, VNC, TELNET, PASS_HSM are intentionally word-split
     qemu-system-x86_64 -machine accel=kvm,vmport=off -m 64G -smp 4 -cpu host -bios OVMF.fd \
-        -monitor unix:./${PROCESS_NAME}.qemumon,server,nowait \
-        -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \
+        -monitor unix:./"${PROCESS_NAME}".qemumon,server,nowait \
+        -name gyroidos-tester,process="${PROCESS_NAME}" -nodefaults -nographic \
         -device virtio-rng-pci,rng=id -object rng-random,id=id,filename=/dev/urandom \
         -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd0 \
-        -drive if=none,id=hd0,file=${PROCESS_NAME}.img,cache=directsync,format=raw \
+        -drive if=none,id=hd0,file="${PROCESS_NAME}".img,cache=directsync,format=raw \
         -device scsi-hd,drive=hd1 \
-        -drive if=none,id=hd1,file=${PROCESS_NAME}.ext4fs,cache=directsync,format=raw \
-        -device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp::$SSH_PORT-:22 \
+        -drive if=none,id=hd1,file="${PROCESS_NAME}".ext4fs,cache=directsync,format=raw \
+        -device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp::"$SSH_PORT"-:22 \
         -drive "if=pflash,format=raw,readonly=on,file=$ovmf_code" \
         -drive "if=pflash,format=raw,file=./OVMF_VARS.fd" \
         $SWTPM \

--- a/resources/check-if-code-is-formatted.sh
+++ b/resources/check-if-code-is-formatted.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
-ROOT_DIR="$(cd "$(dirname "$1")" >/dev/null 2>&1 && pwd)"
+set -euo pipefail
+
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
+
+ROOT_DIR="$(realpath "$(dirname "$1")")"
 CLANG_FORMAT="clang-format"
-FILES=$(find $ROOT_DIR -type f -regextype sed -regex ".*\(\.c\|\.h\)")
+mapfile -t FILES < <(find "$ROOT_DIR" -type f -regextype sed -regex ".*\(\.c\|\.h\)")
 
-echo "Detected clang-format version..."
-$CLANG_FORMAT --version
+einfo "clang-format: $("$CLANG_FORMAT" --version)"
+einfo "Checking ${#FILES[@]} files in $ROOT_DIR"
 
-echo "Checking if code is properly formatted..."
-diff -u <(cat $FILES) <($CLANG_FORMAT $FILES)
-ret=$?
+ret=0
+diff -u <(cat "${FILES[@]}") <("$CLANG_FORMAT" "${FILES[@]}") || ret=$?
 
-if [ $ret -ne 0 ]; then
-    echo ""
-    echo "The code is not formatted!"
-    echo "Check the above output that shows the wrong (-) and correct (+) formattings."
-    echo "You can automatically format your code using the ./scripts/format-code.sh script."
+if [[ $ret -ne 0 ]]; then
+    eerror "Code is not formatted! See diff above."
+    eerror "Run ./scripts/format-code.sh to fix."
 else
-    echo "Code is properly formatted."
+    ok "Code is properly formatted"
 fi
 
-exit $ret
+exit "$ret"

--- a/resources/common.sh
+++ b/resources/common.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This file is part of GyroidOS
+# Copyright(c) 2013 - 2020 Fraunhofer AISEC
+# Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2 (GPL 2), as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses/>
+#
+# The full GNU General Public License is included in this distribution in
+# the file called "COPYING".
+#
+# Contact Information:
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+#
+
+LOG_HNAME="$(hostname)"
+
+eprint(){
+	[[ -n "${LOGFILE:-}" ]] && echo "    $*" >> "$LOGFILE"
+	[[ -n "${QUIET:-}" ]] && return
+	echo "       [1;90m[${LOG_HNAME}] $*[m" >&2
+}
+
+elog() {
+	[[ -n "${LOGFILE:-}" ]] && echo "LOG: $*" >> "$LOGFILE"
+	[[ -n "${QUIET:-}" ]] && return
+	echo "    [[1m+[m][1;90m[${LOG_HNAME}] $*[m" >&2
+}
+
+edebug() {
+	[[ -n "${LOGFILE:-}" ]] && echo "DEBUG: $*" >> "$LOGFILE"
+	[[ -n "${QUIET:-}" ]] && return
+	echo "    [[1;90m+[m][1;90m[${LOG_HNAME}] $*[m" >&2
+}
+
+einfo() {
+	[[ -n "${LOGFILE:-}" ]] && echo "INFO: $*" >> "$LOGFILE"
+	[[ -n "${QUIET:-}" ]] && return
+	echo "    [[1;32m+[m][1;90m[${LOG_HNAME}] $*[m" >&2
+}
+
+eattention() {
+	[[ -n "${LOGFILE:-}" ]] && echo "ATTENTION: $*" >> "$LOGFILE"
+	[[ -n "${QUIET:-}" ]] && return
+	echo "    [[1;33m![m][1;33m[${LOG_HNAME}] $*[m" >&2
+}
+
+ewarn() {
+	[[ -n "${LOGFILE:-}" ]] && echo "WARNING: $*" >> "$LOGFILE"
+	echo "    [[1;33m+[m][1;33m[${LOG_HNAME}] $*[m" >&2
+}
+
+eerror() {
+	[[ -n "${LOGFILE:-}" ]] && echo "ERROR: $*" >> "$LOGFILE"
+	echo "   [1;31m* ERROR[m[1;90m[${LOG_HNAME}]: $*[m" >&2
+}
+
+
+die() {
+	[[ -n "${LOGFILE:-}" ]] && echo "ERROR, FATAL: $*" >> "$LOGFILE"
+	eerror "$*"
+	export DIED_ERROR="yes"
+	exit 1
+}
+
+begin(){
+        [[ -n "${QUIET:-}" ]] && return
+	echo "[1;36m[[1;32mbegin[1;36m][${LOG_HNAME}] $*[m" >&2
+}
+
+ok(){
+        [[ -n "${QUIET:-}" ]] && return
+	echo "[1;36m[[1;32m   ok[1;36m][${LOG_HNAME}] $*[m" >&2
+}
+
+countdown() {
+        echo -n "$2" >&2
+
+        local i="$1"
+        while [[ $i -gt 0 ]]; do
+		echo -n " [1;31m$i[m" >&2
+                i=$((i - 1))
+                sleep 1
+        done
+        echo >&2
+}

--- a/resources/settings.sh
+++ b/resources/settings.sh
@@ -1,5 +1,9 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 export PATH="/sbin/:usr/sbin/:${PATH}"
 
@@ -10,31 +14,33 @@ KILL_VM=false
 IMGPATH=""
 MODE=""
 LOG_DIR=""
-
-# Directory containing test PKI for image
 PKI_DIR=""
-
-# Serial of USB Token
 HSM_SERIAL=""
-
-# Copy root CA from test PKI to image
+HSM_VID=""
+HSM_PID=""
 COPY_ROOTCA="y"
-
 SCRIPTS_DIR=""
-
 TESTPW="pw"
 
-BASE_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=${PROCESS_NAME}.vm_key -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=5"
-SCP_OPTS="-P $SSH_PORT $BASE_OPTS"
-SSH_OPTS="-p $SSH_PORT $BASE_OPTS root@localhost"
+COMPILE=false
+BRANCH=""
+FORCE=false
+VNC=""
+TELNET=""
+PASS_HSM=""
+SWTPM=""
+OPT_FORCE_SIG_CFGS="${OPT_FORCE_SIG_CFGS:-n}"
+OPT_CC_MODE_EXPERIMENTAL="${OPT_CC_MODE_EXPERIMENTAL:-n}"
+
+BASE_OPTS=(-o StrictHostKeyChecking=no -o "UserKnownHostsFile=${PROCESS_NAME}.vm_key" -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=5)
+SCP_OPTS=(-P "$SSH_PORT" "${BASE_OPTS[@]}")
+SSH_OPTS=(-p "$SSH_PORT" "${BASE_OPTS[@]}" root@localhost)
 
 ###################################################################################################
 # COMMAND LINE INTERFACE
 ###################################################################################################
 parse_cli() {
-    # Argument retrieval
-    # -----------------------------------------------
-    while [[ $# > 0 ]]; do
+    while [[ $# -gt 0 ]]; do
     case $1 in
         -h|--help)
         echo -e "Performs set of tests to start, stop and modify containers in VM among other operations."
@@ -62,153 +68,56 @@ parse_cli() {
         echo "-r, --scripts-dir	Specify directory containing signing scripts (gyroidos_build repo)"
         exit 1
         ;;
-        -c|--compile)
-        COMPILE=true
-        shift
-        ;;
-        -b|--branch)
-        shift
-        BRANCH=$1
-        if [[ $BRANCH  == "" ]]
-        then
-            echo_error "No branch specified. Run with --help for more information."
-            exit 1
-        fi
-        shift
-        ;;
+        -c|--compile)       COMPILE=true; shift ;;
+        -b|--branch)        shift; BRANCH=$1; [[ -n "$BRANCH" ]] || die "No branch specified"; shift ;;
         -d|--dir)
         shift
-        if [[ $1  == "" || ! -d $1 ]]
-        then
-            echo_error "No (existing) directory specified. Run with --help for more information."
-            exit 1
-        fi
-        echo_status "changing to directory $(pwd)"
-        cd $1
-        echo_status "changed to directory $(pwd)"
-        shift
+        [[ -n "$1" && -d "$1" ]] || die "No (existing) directory specified"
+        cd "$1"; shift  # cd is intentional: --dir sets cwd for all subsequent operations
         ;;
-        -o|--builddir)
-        shift
-        BUILD_DIR="$(readlink -v -f $1)"
-        shift
-        ;;
-        -f|--force)
-        shift
-        FORCE=true
-        ;;
+        -o|--builddir)      shift; BUILD_DIR="$(readlink -v -f "$1")"; shift ;;
+        -f|--force)         shift; FORCE=true ;;
         -v|--vnc)
-        shift
-        if ! [[ $1 =~ ^[0-9]+$ ]]
-        then
-            echo_error "VNC port must be a number. (got $1)"
-            exit 1
-        fi
-        VNC="-vnc 0.0.0.0:$1 -vga std"
-        shift
+        shift; [[ $1 =~ ^[0-9]+$ ]] || die "VNC port must be a number (got $1)"
+        VNC="-vnc 0.0.0.0:$1 -vga std"; shift
         ;;
         -s|--ssh)
-        shift
-        SSH_PORT=$1
-        if ! [[ $SSH_PORT =~ ^[0-9]+$ ]]
-        then
-            echo_error "ssh host port must be a number. (got $SSH_PORT)"
-            exit 1
-        fi
+        shift; SSH_PORT=$1; [[ $SSH_PORT =~ ^[0-9]+$ ]] || die "SSH port must be a number (got $SSH_PORT)"
         shift
         ;;
         -t|--telnet)
-        shift
-        if ! [[ $1 =~ ^[0-9]+$ ]]
-        then
-            echo_error "telnet host port must be a number. (got $1)"
-            exit 1
-        fi
-        TELNET="-serial mon:telnet:127.0.0.1:$1,server,nowait"
-        shift
+        shift; [[ $1 =~ ^[0-9]+$ ]] || die "Telnet port must be a number (got $1)"
+        TELNET="-serial mon:telnet:127.0.0.1:$1,server,nowait"; shift
         ;;
-        -k|--kill)
-        shift
-        KILL_VM=true
-        ;;
-        -n|--name)
-        shift
-        PROCESS_NAME=$1
-        shift
-        ;;
-        -p|--pki)
-        shift
-        PKI_DIR="$(readlink -v -f $1)"
-        shift
-        ;;
-        -i|--image)
-        shift
-        IMGPATH=$1
-        shift
-        ;;
+        -k|--kill)          shift; KILL_VM=true ;;
+        -n|--name)          shift; PROCESS_NAME=$1; shift ;;
+        -p|--pki)           shift; PKI_DIR="$(readlink -v -f "$1")"; shift ;;
+        -i|--image)         shift; IMGPATH=$1; shift ;;
         -m|--mode)
         shift
-        if ! [[ "$1" = "dev" ]] && ! [[ $1 = "production" ]] && ! [[ "$1" = "ccmode" ]];then
-        echo_error "Unkown mode \"$1\" specified. Exiting..."
-        exit 1
-        fi
-        echo_status "Testing \"$1\" image"
-        MODE=$1
-        shift
+        [[ "$1" = "dev" || "$1" = "production" || "$1" = "ccmode" ]] || die "Unknown mode \"$1\""
+        MODE=$1; shift
         ;;
         -e|--enable-hsm)
-        shift
-        HSM_SERIAL="$1"
-        shift
-        HSM_VID="$1"
-        shift
-        HSM_PID="$1"
-        shift
-        TESTPW="$1"
+        shift; HSM_SERIAL="$1"; shift; HSM_VID="$1"; shift; HSM_PID="$1"; shift; TESTPW="$1"
         PASS_HSM="-usb -device qemu-xhci -device usb-host,vendorid=0x${HSM_VID},productid=0x${HSM_PID}"
-        echo_status "Enable sc-hsm tests for token ${HSM_SERIAL}"
         shift
         ;;
-        -k|--skip-rootca)
-        COPY_ROOTCA="n"
-        shift
-        ;;
-        -r| --scripts-dir)
-        shift
-        SCRIPTS_DIR="$(readlink -v -f $1)"
-        shift
-        ;;
-        -l| --log-dir)
-        shift
-        LOG_DIR="$(readlink -v -m $1)"
-        shift
-        ;;
-        --force-sig-cfgs)
-          echo "Enforcing signed configs"
-          OPT_FORCE_SIG_CFGS="y"
-          shift
-          ;;
-        --cc-mode-experimental)
-          echo "Testing with CC_MODE_EXPERIMENTAL enabled"
-          OPT_CC_MODE_EXPERIMENTAL="y"
-          shift
-          ;;
-
-        *)
-        echo_error "Unknown arguments specified? ($1)"
-        exit 1
-        ;;
+        -k|--skip-rootca)   COPY_ROOTCA="n"; shift ;;
+        -r|--scripts-dir)   shift; SCRIPTS_DIR="$(readlink -v -f "$1")"; shift ;;
+        -l|--log-dir)       shift; LOG_DIR="$(readlink -v -m "$1")"; shift ;;
+        --force-sig-cfgs)   OPT_FORCE_SIG_CFGS="y"; shift ;;
+        --cc-mode-experimental) OPT_CC_MODE_EXPERIMENTAL="y"; shift ;;
+        *) die "Unknown argument: $1" ;;
     esac
     done
 
-    # check PKI dir
-    if [[ -z "${PKI_DIR}" ]];then
-        echo_status "--pki not specified, assuming \"test_certificates\""
+    # Rebuild opts arrays after SSH_PORT may have changed
+    SCP_OPTS=(-P "$SSH_PORT" "${BASE_OPTS[@]}")
+    SSH_OPTS=(-p "$SSH_PORT" "${BASE_OPTS[@]}" root@localhost)
+
+    if [[ -z "${PKI_DIR}" ]]; then
         PKI_DIR="test_certificates"
     fi
-
-    if ! [ -d "${PKI_DIR}" ];then
-        echo_error "No PKI given, exiting..."
-        exit 1
-    fi
+    [[ -d "${PKI_DIR}" ]] || die "PKI directory not found: ${PKI_DIR}"
 }

--- a/resources/store-revisions.sh
+++ b/resources/store-revisions.sh
@@ -1,6 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 UPSTREAM="gyroidos"
 
@@ -13,58 +16,43 @@ OUT="$(realpath .)"
 AUTO_CONF_SUFFIX=""
 
 parse_manifest() {
-	manifest="$1"
-	outfile="$OUT/$(basename "$manifest").revisions"
+	local manifest="$1"
+	local outfile="$OUT/$(basename "$manifest").revisions"
 
-	while IFS= read l || [ -n "$l" ];do
-		if [[ $l == *"<project"* ]];then
-			echo "Processing $l"
+	while IFS= read -r l || [[ -n "$l" ]]; do
+		if [[ "$l" == *"<project"* ]]; then
+			oldrev="$(echo "$l" | sed -nE 's|.*revision="([a-z0-9._]*)".*|\1|p')"
+			repo="$(echo "$l" | sed -nE 's|.*name="([/a-z0-9_\-]*)".*|\1|p')"
+			path="$(echo "$l" | sed -nE 's|.*path="([/a-z0-9_\-]*)".*|\1|p')"
 
-			oldrev="$(echo $l | sed -nE 's|.*revision="([a-z0-9._]*)".*|\1|p')"
-			repo="$(echo $l | sed -nE 's|.*name="([/a-z0-9_\-]*)".*|\1|p')"
-			path="$(echo $l | sed -nE 's|.*path="([/a-z0-9_\-]*)".*|\1|p')"
+			[[ -n "$path" ]] || die "Failed to parse repo path for line: $l"
 
-			if [ -z "$path" ] ;then
-				echo "Error: failed to parse repo path for line $l"
-				exit 1
+			newrev="$(git -C "$path" rev-parse HEAD)" || true
+
+			if [[ -z "$repo" ]] || [[ -z "$path" ]] || [[ -z "${newrev:-}" ]]; then
+				die "Failed to parse line: $l (oldrev=$oldrev, repo=$repo, path=$path, newrev=${newrev:-})"
 			fi
 
-			newrev="$(git -C $path rev-parse HEAD)"
-
-			if [ -z "$repo" ] || [ -z "$path" ] || [ -z $newrev ];then
-				echo "Error: failed to parse line $l, oldrev=$oldrev, repo=$repo, path=$path, newrev=$newrev"
-				exit 1
-			fi
-
-			if ! [ -z "$oldrev" ];then
-				echo "Replacing rev for repo $repo at $path: $oldrev => $newrev"
+			if [[ -n "$oldrev" ]]; then
 				l_new=$(echo "$l" | sed -nE "s/revision=\"([a-z0-9._]*)\"/revision=\"$newrev\"/p")
-				echo "l_new=$l_new"
-				printf "$l_new\n" >> "$outfile"
+				printf "%s\n" "$l_new" >> "$outfile"
 			else
-				echo "Adding new rev entry for repo $repo at $path on remote $remote: <default rev: $default_remote> => $newrev"
-
-				if [ -z "$(echo "$l" | grep "/>")" ];then
-					l_new=$(echo "$l" | sed -nE "s|>|revision=\"$newrev\">|p")
-				else
+				if [[ "$l" == *"/>"* ]]; then
 					l_new=$(echo "$l" | sed -nE "s|/>|revision=\"$newrev\"/>|p")
+				else
+					l_new=$(echo "$l" | sed -nE "s|>|revision=\"$newrev\">|p")
 				fi
-
-				echo "l_new=$l_new"
-
-				printf "$l_new\n" >> "$outfile"
-
+				printf "%s\n" "$l_new" >> "$outfile"
 			fi
 		else
-			printf "$l\n" >> "$outfile"
+			printf "%s\n" "$l" >> "$outfile"
 		fi
 	done < "$manifest"
 }
 
 
 # Argument retrieval
-# -----------------------------------------------
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   case $1 in
     -h|--help)
       echo -e "Creates a copy of the given manifest containing the checked-out revisions of Yocto layers, CML and kernel"
@@ -81,159 +69,76 @@ while [[ $# > 0 ]]; do
       echo "--gyroid_machine            GyroidOS machine being build"
       exit 1
       ;;
-    -m|--manifest)
-      shift
-      MANIFEST_PATH="$(realpath $1)"
-      shift
-      ;;
-    -w|--workspace)
-      shift
-      WS_PATH="$(realpath $1)"
-      shift
-      ;;
-    -b|--buildhistory)
-      shift
-      BH_PATH="$(realpath $1)"
-      shift
-      ;;
-    -c|--cml)
-      shift
-	  CML="y"
-      ;;
-    -o|--out)
-      shift
-      OUT="$(realpath $1)" 
-      shift
-      ;;
-    --gyroid_machine)
-      shift
-      AUTO_CONF_SUFFIX="_$1"
-      shift
-      ;;
-
-
-     *)
-	  echo "ERROR: Unknown arguments specified? ($1)"
-      exit 1
-      ;;
+    -m|--manifest)      shift; MANIFEST_PATH="$(realpath "$1")"; shift ;;
+    -w|--workspace)     shift; WS_PATH="$(realpath "$1")"; shift ;;
+    -b|--buildhistory)  shift; BH_PATH="$(realpath "$1")"; shift ;;
+    -c|--cml)           shift; CML="y" ;;
+    -o|--out)           shift; OUT="$(realpath "$1")"; shift ;;
+    --gyroid_machine)   shift; AUTO_CONF_SUFFIX="_$1"; shift ;;
+    *) die "Unknown argument: $1" ;;
   esac
 done
 
 BASE_MANIFEST_PATH="$(dirname "${MANIFEST_PATH}")/gyroidos-base.xml"
 ROLLING_SRCREV=""
-if [ -n "$BH_PATH" ];then
-	ROLLING_SRCREV="$(find "$BH_PATH/packages" -wholename '*/linux-*/latest_srcrev')"
+if [[ -n "$BH_PATH" ]]; then
+	ROLLING_SRCREV="$(find "$BH_PATH/packages" -wholename '*/linux-*/latest_srcrev')" || true
 fi
 
-echo "MANIFEST_PATH=${MANIFEST_PATH}"
-echo "BASE_MANIFEST_PATH=${BASE_MANIFEST_PATH}"
-echo "WS_PATH=${WS_PATH}"
-echo "BH_PATH=${BH_PATH}"
-echo "OUT=${OUT}"
-echo "CML=${CML}"
-echo "ROLLING_SRCREV=${ROLLING_SRCREV}"
-echo "AUTO_CONF_SUFFIX=${AUTO_CONF_SUFFIX}"
-
-# sanity checks for parameters
-if [ -z "$WS_PATH" ] || ! [ -d "$WS_PATH" ];then
-	echo "Error: No or non-existing workspace path specified, exiting..."
-	exit 1
+# sanity checks
+[[ -n "$WS_PATH" && -d "$WS_PATH" ]] || die "No or non-existing workspace path: ${WS_PATH:-<empty>}"
+[[ -n "$MANIFEST_PATH" && -f "$MANIFEST_PATH" ]] || die "No or non-existing manifest path: ${MANIFEST_PATH:-<empty>}"
+if [[ "y" == "$CML" ]] && [[ -z "$BH_PATH" ]]; then
+	die "--cml specified but no path to buildhistory given"
 fi
-
-if [ -z "$MANIFEST_PATH" ] || ! [ -f "$MANIFEST_PATH" ];then
-	echo "Error: No or non-existing manifest path specified, exiting..."
-	exit 1
-fi
-
-if [ "y" = "$CML" ] && [ -z "$BH_PATH" ];then
-	echo "Error: --cml specified but no path to buildhistory given, exiting..."
-	exit 1
-fi
-
-
-echo "Storing revisions to new manifest at $OUT/manifest_revisions.xml"
-cd "${WS_PATH}"
 
 # Parse default remote
-if [ -z "$repo" ];then
-	default_remote="$(sed -nE '0,/remote=/{s|.*remote="([[:alpha:]]*)".*|\1|p}' ${MANIFEST_PATH})"
+default_remote="$(sed -nE '0,/remote=/{s|.*remote="([[:alpha:]]*)".*|\1|p}' "${MANIFEST_PATH}")"
+[[ -n "${default_remote:-}" ]] || die "Failed to parse default remote from manifest"
+
+begin "Storing revisions"
+einfo "Manifest: $(basename "$MANIFEST_PATH"), workspace: $WS_PATH"
+
+(cd "${WS_PATH}" && parse_manifest "$MANIFEST_PATH")
+
+if [[ -f "${BASE_MANIFEST_PATH}" ]]; then
+	elog "Parsing base manifest: $(basename "$BASE_MANIFEST_PATH")"
+	(cd "${WS_PATH}" && parse_manifest "$BASE_MANIFEST_PATH") || true
 fi
 
-if [ -z "$default_remote" ];then
-	echo "Failed to get default remote, exiting..."
-	exit 1
-fi
-
-echo "Default remote: $default_remote"
-
-# Parse manifest and store revisions of Yocto layers
-
-echo "Parsing $MANIFEST_PATH"
-set +e
-parse_manifest "$MANIFEST_PATH"
-set -e
-
-if [ -f "${BASE_MANIFEST_PATH}" ];then
-	echo "Attempting to parse base manifest at ${BASE_MANIFEST_PATH}"
-	set +e
-	parse_manifest "$BASE_MANIFEST_PATH" || true
-	set -e
-else
-	echo "No base manifest at ${BASE_MANIFEST_PATH} detected, skipping..."
-fi
-
-echo 'Successfully stored revisions in manifest(s)'
-#
 # Store revision of linux-rolling-{stable|lts}
-if [ -n "${ROLLING_SRCREV}" ] || [ "y" == "${CML}" ];then
+if [[ -n "${ROLLING_SRCREV}" ]] || [[ "y" == "${CML}" ]]; then
 	echo -n > "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
 fi
 
-if [ -n "${ROLLING_SRCREV}" ];then
-	echo "Writing linux-rolling revision to auto.conf"
-
-	cat ${ROLLING_SRCREV} >> "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
-
-	echo 'Successfully stored revision of linux-rolling'
+if [[ -n "${ROLLING_SRCREV}" ]]; then
+	elog "Writing linux-rolling revision to auto.conf"
+	cat "${ROLLING_SRCREV}" >> "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
 fi
 
-
 # Store CML revisions
-if [ "y" == "$CML" ]; then
-	echo "Writing CML revisions to auto${AUTO_CONF_SUFFIX}.conf"
-
-	srcrevpath="$(find "$BH_PATH/packages" -wholename '*/cmld/latest_srcrev')"
-	if [ -z "$srcrevpath" ];then
-		echo "Failed to find file */cmld/latest_srcrev in buildhistory, \
-			  attempting to fetch revision from $WS_PATH/gyroidos/cml."
-
-		if [ -d "$WS_PATH/gyroidos/cml" ];then
-			srcrev="$(git -C "$WS_PATH/gyroidos/cml" rev-parse HEAD)"
-			echo "CML revision in EXTERNALSRC build is $srcrev"
-		else
-			echo "Could not find directory holding cml git."
-			exit 1
-		fi
+if [[ "y" == "$CML" ]]; then
+	srcrevpath="$(find "$BH_PATH/packages" -wholename '*/cmld/latest_srcrev')" || true
+	if [[ -z "${srcrevpath:-}" ]]; then
+		[[ -d "$WS_PATH/gyroidos/cml" ]] || die "Could not find cml git directory"
+		srcrev="$(git -C "$WS_PATH/gyroidos/cml" rev-parse HEAD)"
+		elog "CML revision (EXTERNALSRC): $srcrev"
 	else
 		tmprev=""
-		for path in $srcrevpath;do
+		for path in $srcrevpath; do
 			srcrev="$(sed -nE 's|^SRCREV.* = "([a-z0-9._]*)".*|\1|p' "$path")"
-
-			if ! [ "" = "$tmprev" ] && [ "$tmprev" != "$srcrev" ];then
-				echo "ERROR: Multiple cmld evisions detected, changed during build? (srcrev '$srcrev' != tmprev '$tmprev')"
-				exit 1
+			if [[ -n "$tmprev" ]] && [[ "$tmprev" != "$srcrev" ]]; then
+				die "Multiple cmld revisions detected: '$srcrev' != '$tmprev'"
 			fi
 			tmprev="$srcrev"
 		done
-
-		echo "CML revision from buildhistory is $srcrev"
+		elog "CML revision (buildhistory): $srcrev"
 	fi
 
 	echo "SRCREV:pn-cmld = \"${srcrev}\"" >> "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
 	echo "SRCREV:pn-service = \"${srcrev}\"" >> "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
 	echo "SRCREV:pn-service-static = \"${srcrev}\"" >> "$OUT/auto${AUTO_CONF_SUFFIX}.conf"
-
-	echo 'Successfully stored CML revisions'
 fi
 
+ok "Stored revisions"
 exit 0

--- a/resources/testdata.sh
+++ b/resources/testdata.sh
@@ -1,11 +1,15 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 do_create_testconfigs() {
 # Create container configuration files for tests
 # -----------------------------------------------
 
-if [[ -z "$SCHSM_SERIAL" ]];then
+if [[ -z "${SCHSM_SERIAL:-}" ]]; then
 
 cat > ./testcontainer.conf << EOF
 name: "testcontainer"
@@ -270,22 +274,6 @@ EOF
 
 fi
 
-echo_status "Prepared testcontainer.conf:"
-echo "$(cat ./testcontainer.conf)"
-
-echo_status "Prepared signedcontainer1.conf:"
-echo "$(cat ./signedcontainer1.conf)"
-
-echo_status "Prepared signedcontainer1_update.conf:"
-echo "$(cat ./signedcontainer1_update.conf)"
-
-echo_status "Prepared signedcontainer1_rename.conf:"
-echo "$(cat ./signedcontainer1_rename.conf)"
-
-echo_status "Prepared signedcontainer2.conf:"
-echo "$(cat ./signedcontainer2.conf)"
-
-
 cat > ./rmcontainer3.conf << EOF
 name: "rmcontainer3"
 guest_os: "gyroidos-coreos"
@@ -297,10 +285,6 @@ image_sizes {
 }
 EOF
 
-echo_status "Prepared rmcontainer3.conf:"
-echo "$(cat ./rmcontainer3.conf)"
-
-
 cat > ./c0.conf << EOF
 name: "core0"
 guest_os: "gyroidos-coreos"
@@ -308,10 +292,6 @@ guestos_version: $installed_guestos_version
 assign_dev: "c 4:1 rwm"
 allow_dev: "b 8:* rwm"
 EOF
-
-
-echo_status "Prepared c0.conf:"
-echo "$(cat ./c0.conf)"
 
 
 cat > ./nullos-1.conf << EOF
@@ -384,75 +364,47 @@ build_date: "$(date +%F%T%Z -u)"
 EOF
 
 
-echo_status "Prepared nullos-1.conf:"
-echo "$(cat ./nullos-1.conf)"
-
-echo_status "Prepared nullos-2.conf:"
-echo "$(cat ./nullos-2.conf)"
-
-echo_status "Prepared nullos-3.conf:"
-echo "$(cat ./nullos-3.conf)"
-
-
-echo "PKI_DIR there?: $PKI_DIR"
 # Sign signedcontainer{1,2}.conf, c0.conf (enforced in production and ccmode images)
-if [[ -d "$PKI_DIR" ]];then
-	echo "A"
+if [[ -d "$PKI_DIR" ]]; then
 	scripts_path=""
-	if ! [[ -z "${SCRIPTS_DIR}" ]];then
+	if [[ -n "${SCRIPTS_DIR}" ]]; then
 		scripts_path="${SCRIPTS_DIR}/"
-	elif ! [[ -z "${BUILD_DIR}" ]];then
-		echo_status "--scripts-dir not given, assuming \"../gyroidos/build\""
+	elif [[ -n "${BUILD_DIR}" ]]; then
 		scripts_path="$(pwd)/../gyroidos/build"
-		echo "scripts_path: $scripts_path"
 	else
-		echo_status "--scripts-dir not given, assuming \"./gyroidos/build\""
 		scripts_path="$(pwd)/gyroidos/build"
 	fi
 
-	echo "B"
-	if ! [[ -d "$scripts_path" ]];then
-		echo_status "Could not find gyroidos_build directory at $scripts_path."
+	if ! [[ -d "$scripts_path" ]]; then
+		ewarn "Could not find gyroidos_build directory at $scripts_path."
 		read -r -p "Download from GitHub?" -n 1
 
-		if [[ "$REPLY" == "y" ]];then
+		if [[ "$REPLY" == "y" ]]; then
 			mkdir -p "$scripts_path"
-			echo_status "Got y, downloading gyroidos_build repository to $scripts_path"
 			git clone https://github.com/gyroidos/gyroidos_build.git "$scripts_path"
 		fi
 	fi
 
-	echo "c"
-
-	if ! [ -f "$scripts_path/device_provisioning/oss_enrollment/config_creator/sign_config.sh" ];then
-		echo_error "Could not find sign_config.sh at $scripts_path/device_provisioning/oss_enrollment/config_creator/sign_config.sh. Exiting..."
-		exit 1
+	if ! [[ -f "$scripts_path/device_provisioning/oss_enrollment/config_creator/sign_config.sh" ]]; then
+		die "Could not find sign_config.sh at $scripts_path/device_provisioning/oss_enrollment/config_creator/sign_config.sh"
 	fi
 
 	signing_script="$scripts_path/device_provisioning/oss_enrollment/config_creator/sign_config.sh"
 
-	if ! [[ -f "$signing_script" ]];then
-		echo_error "$signing_script does not exist or is not a regular file. Exiting..."
-		exit 1
+	if ! [[ -f "$signing_script" ]]; then
+		die "$signing_script does not exist or is not a regular file"
 	fi
 
-	echo_status "Signing container configuration files using PKI at ${PKI_DIR} and $signing_script"
-
+	einfo "Signing configs with PKI at ${PKI_DIR}"
 
 	for conf in "signedcontainer1" "signedcontainer1_update" "signedcontainer1_rename" "signedcontainer2" "rmcontainer3" "c0"; do
-		echo "bash \"$signing_script\" \"./$conf.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 		bash "$signing_script" "./$conf.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
 	done
 
-
-	echo_status "Signing guestos configuration files using using PKI at ${PKI_DIR} and $signing_script"
-
 	for I in $(seq 1 3); do
-		echo "bash \"$signing_script\" \"./nullos-${I}.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 		bash "$signing_script" "./nullos-${I}.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
 	done
 
-	echo_status "Signing kernel update using using PKI at ${PKI_DIR} and $signing_script"
 	# obtain the guestos verion of the current kernel, should match the installed one
 	KERNEL_VERSION=$(gawk 'match($0, /^version: (.*)/, ary) {print ary[1]}' kernel/kernel-*.conf)
 	KERNEL_VERSION_NEW=$(($KERNEL_VERSION + 1))
@@ -463,43 +415,40 @@ if [[ -d "$PKI_DIR" ]];then
 	cp -r kernel/kernel-$KERNEL_VERSION kernel-$KERNEL_VERSION_NEW
 	sed -i "s/$KERNEL_VERSION/$KERNEL_VERSION_NEW/g" kernel-$KERNEL_VERSION_NEW.conf
 
-	echo "bash \"$signing_script\" \"./kernel-$KERNEL_VERSION_NEW.conf\" \"${PKI_DIR}/ssig_cml.key\" \"${PKI_DIR}/ssig_cml.cert\""
 	bash "$signing_script" "./kernel-$KERNEL_VERSION_NEW.conf" "${PKI_DIR}/ssig_cml.key" "${PKI_DIR}/ssig_cml.cert"
 else
-	echo_error "No test PKI found at $PKI_DIR, exiting..."
-	exit 1
+	die "No test PKI found at $PKI_DIR"
 fi
 
-echo_status "Signed signedcontainer{1,2}.conf, signedcontainer1_{update,rename}.conf, rmcontainer3.conf, c0.conf:"
 }
 
 do_copy_configs(){
-# Copy test container configs to VM
+local -a FILES
 for I in $(seq 1 10) ;do
-	echo_status "Trying to copy container configs to image"
-
 	# copy only .conf if signing was skipped
-	if [ -f signedcontainer1.sig ];then
-		FILES="testcontainer.conf signedcontainer1.conf signedcontainer1.sig signedcontainer1.cert \
-			   signedcontainer1_update.conf signedcontainer1_update.sig signedcontainer1_update.cert \
-			   signedcontainer1_rename.conf signedcontainer1_rename.sig signedcontainer1_rename.cert \
-			   signedcontainer2.conf signedcontainer2.sig signedcontainer2.cert \
-			   rmcontainer3.conf rmcontainer3.sig rmcontainer3.cert \
-			   c0.conf c0.sig c0.cert"
+	if [[ -f signedcontainer1.sig ]]; then
+		FILES=(
+			testcontainer.conf
+			signedcontainer1.conf signedcontainer1.sig signedcontainer1.cert
+			signedcontainer1_update.conf signedcontainer1_update.sig signedcontainer1_update.cert
+			signedcontainer1_rename.conf signedcontainer1_rename.sig signedcontainer1_rename.cert
+			signedcontainer2.conf signedcontainer2.sig signedcontainer2.cert
+			rmcontainer3.conf rmcontainer3.sig rmcontainer3.cert
+			c0.conf c0.sig c0.cert
+		)
 	else
-		FILES="signedcontainer1.conf signedcontainer1_update.conf signedcontainer2.conf c0.conf \
-			   sigendcontainer1_rename.conf rmcontainer3.conf"
-
+		FILES=(
+			signedcontainer1.conf signedcontainer1_update.conf signedcontainer2.conf
+			c0.conf signedcontainer1_rename.conf rmcontainer3.conf
+		)
 	fi
 
-	if scp $SCP_OPTS $FILES root@127.0.0.1:/tmp/;then
-		echo_status "scp was successful"
+	if scp "${SCP_OPTS[@]}" "${FILES[@]}" root@127.0.0.1:/tmp/; then
 		break
-	elif ! [ $I -eq 10 ];then
-		echo_status "scp failed, retrying..."
-	else
-		echo_status "Failed to copy container configs to VM, exiting..."
+	elif [[ "$I" -eq 10 ]]; then
+		eerror "Failed to copy container configs to VM after 10 attempts"
 		err_fetch_logs
 	fi
+	sleep 0.5
 done
 }

--- a/resources/unit-testing.sh
+++ b/resources/unit-testing.sh
@@ -1,35 +1,27 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+RUNDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+# shellcheck source=common.sh
+source "${RUNDIR}/common.sh"
 
 # Jenkins executes this script before it builds the gyroidos image (i.e. pre-yocto).
 # If this script exits with a non-zero code, the whole pipeline fails.
-# Right now it is used to execute the unit tests in libcommon
-# However, it can be extended and used for any pre-build-time task (fuzzing, other tests, etc).
 
-set -e
-set -o pipefail
+REPO_DIR="$(realpath "$1")"
 
-REPO_DIR="$(cd "$1" >/dev/null 2>&1 && pwd)"
-
-# Piggyback on the compiler's static analysis;
-# Build every subproject with enabled aggressive warnings;
-# Check if the compiler catches any errors
 dirs=(common control converter daemon scd)
-for d in ${dirs[*]}; do
-    cd "${REPO_DIR}/common"
-    make clean
-
-    cd "${REPO_DIR}/${d}"
-    make clean
-    AGGRESSIVE_WARNINGS=y make
-    make clean
+for d in "${dirs[@]}"; do
+    begin "Static analysis: ${d}"
+    make -C "${REPO_DIR}/common" clean
+    make -C "${REPO_DIR}/${d}" clean
+    AGGRESSIVE_WARNINGS=y make -C "${REPO_DIR}/${d}"
+    make -C "${REPO_DIR}/${d}" clean
+    ok "Static analysis: ${d}"
 done
 
-# Execute the unit tests for libcommon without sanitizers
-# TODO: Execute the unit tests for libcommon with enabled sanitizers
-# TODO: write more libcommon tests
-cd "${REPO_DIR}/common"
-make clean
-SANITIZERS=n make test
-make clean
-
-#TODO: execute here other tests or other pre-yocto jobs
+begin "Unit tests: libcommon"
+make -C "${REPO_DIR}/common" clean
+SANITIZERS=n make -C "${REPO_DIR}/common" test
+make -C "${REPO_DIR}/common" clean
+ok "Unit tests: libcommon"

--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -56,6 +56,8 @@ def call(Map target) {
 		env.GYROIDOS_PLAIN_DATAPART = "${("production" == target.buildtype) || ("ccmode" == target.buildtype) || ("schsm" == target.buildtype) || ("bnse" == target.buildtype) || ("hwhsm" == target.buildtype) ? '1' : '0'}"
 
 		sh label: 'Prepare build directory', script: """
+			set -e
+
 			export LC_ALL=en_US.UTF-8
 			export LANG=en_US.UTF-8
 			export LANGUAGE=en_US.UTF-8
@@ -67,6 +69,7 @@ def call(Map target) {
 			cd ${target.workspace}/
 
 			. gyroidos/build/yocto/init_ws_ids.sh out-${target.buildtype} ${target.gyroid_arch} ${target.gyroid_machine}
+			set -e
 
 			if  [ "asan" = "${BUILDTYPE}" ];then
 				cd ${target.workspace}/

--- a/vars/stepFormatCheck.groovy
+++ b/vars/stepFormatCheck.groovy
@@ -7,8 +7,8 @@ def call(Map target) {
 	echo "Entering stepFormatCheck with parameters\n\tsourcedir ${target.sourcedir},\n\tworkspace: ${target.workspace}"
 	sh label: 'Clean CML Repo', script: "git -C ${target.sourcedir} clean -fx"
 
-	checkscript = libraryResource('check-if-code-is-formatted.sh')	
-	writeFile file: "${target.workspace}/check-if-code-is-formatted.sh", text: "${checkscript}"	
+	writeFile file: "${target.workspace}/common.sh", text: libraryResource('common.sh')
+	writeFile file: "${target.workspace}/check-if-code-is-formatted.sh", text: libraryResource('check-if-code-is-formatted.sh')
 
 	sh label: 'Check code formatting', script: "bash ${target.workspace}/check-if-code-is-formatted.sh ${target.sourcedir}"
 }

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -47,17 +47,12 @@ def integrationTestX86(Map target = [:]) {
 	sh label: "Extract image", script: 'tar -I "xz -T 0" -xf gyroidosimage.tar.xz'
 
 
-	testscript = libraryResource('VM-container-tests.sh')	
-	container_commands = libraryResource('VM-container-commands.sh')
-	vm_commands = libraryResource('VM-management.sh')
-	testsettings = libraryResource('settings.sh')
-	testdata = libraryResource('testdata.sh')	
-
-	writeFile file: "${target.workspace}/VM-container-tests.sh", text: "${testscript}"
-	writeFile file: "${target.workspace}/VM-container-commands.sh", text: "${container_commands}"
-	writeFile file: "${target.workspace}/VM-management.sh", text: "${vm_commands}"
-	writeFile file: "${target.workspace}/settings.sh", text: "${testsettings}"
-	writeFile file: "${target.workspace}/testdata.sh", text: "${testdata}"
+	writeFile file: "${target.workspace}/common.sh", text: libraryResource('common.sh')
+	writeFile file: "${target.workspace}/VM-container-tests.sh", text: libraryResource('VM-container-tests.sh')
+	writeFile file: "${target.workspace}/VM-container-commands.sh", text: libraryResource('VM-container-commands.sh')
+	writeFile file: "${target.workspace}/VM-management.sh", text: libraryResource('VM-management.sh')
+	writeFile file: "${target.workspace}/settings.sh", text: libraryResource('settings.sh')
+	writeFile file: "${target.workspace}/testdata.sh", text: libraryResource('testdata.sh')
 
 	def runActualTest = {
 		catchError(message: 'Integration test failed', stageResult: 'FAILURE') {

--- a/vars/stepStoreRevisions.groovy
+++ b/vars/stepStoreRevisions.groovy
@@ -7,8 +7,8 @@ def call(Map target) {
 
 	echo "Entering stepStoreRevisions with parameters workspace: ${target.workspace},\n\tbuildytpe: ${target.buildtype},\n\tmanifest_path: ${target.manifest_path}\n\tgyroid_machine: ${target.gyroid_machine}"
 
-	testscript = libraryResource('store-revisions.sh')	
-	writeFile file: "${target.workspace}/store-revisions.sh", text: "${testscript}"
+	writeFile file: "${target.workspace}/common.sh", text: libraryResource('common.sh')
+	writeFile file: "${target.workspace}/store-revisions.sh", text: libraryResource('store-revisions.sh')
 
 	sh label: 'Creating manifest_revisions.xml and auto.conf', script: """
 

--- a/vars/stepUnitTests.groovy
+++ b/vars/stepUnitTests.groovy
@@ -11,8 +11,8 @@ def call(Map target) {
 
 	sh label: 'Clean CML Repo', script: "git -C ${target.sourcedir} clean -fx"
 
-	testscript = libraryResource('unit-testing.sh')	
-	writeFile file: "${target.workspace}/unit-testing.sh", text: "${testscript}"
+	writeFile file: "${target.workspace}/common.sh", text: libraryResource('common.sh')
+	writeFile file: "${target.workspace}/unit-testing.sh", text: libraryResource('unit-testing.sh')
 
 	sh label: 'Perform unit tests', script: """
 		cd ${target.sourcedir}/common/testdata && bash gen_testvectors.sh


### PR DESCRIPTION
Rewrite scripts to adhere to shell scripting best practices.
- set -euo pipefail (sane defaults)
- /usr/bin/env bash (portability)
- Do not use `cd`, use -C and env -C -> Make scripts independent of cwd -> Make sure, a script leaves us in the location we previously were
- Move to [[ X? ]] (from [ X? ])
- Use socat with a timeout for QEMU socket operations

- Proper quoting
- use of arrays
- Decrease verbosity
- Proper logging wrappers
- Remove dead comments