### PR TITLE
vars/stepBuildImage: Do not use glob

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -112,14 +112,12 @@ def call(Map target) {
 	stepStoreRevisions(workspace: target.workspace, buildtype: "${target.buildtype}", manifest_path: target.manifest_path, manifest_name: target.manifest_name, gyroid_machine: target.gyroid_machine)
 
 	sh label: 'Compress gyroidosimage.img', script: """
-		cd ${target.workspace}/out-${target.buildtype}/tmp/deploy/images/*
-		tar -I "xz -T 0" -C gyroidos_image -cf gyroidosimage.tar.xz --dereference gyroidosimage.img gyroidosimage.img.bmap
+		tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.xz" -C "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidos_image" --dereference gyroidosimage.img gyroidosimage.img.bmap
 	"""
 
 	if (target.containsKey("build_installer") && "y" == target.build_installer) {
 		sh label: 'Compress gyroidosinstaller.img', script: """
-			cd ${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/*
-			tar -I "xz -T 0" -C gyroidos_image -cf gyroidosinstaller.tar.xz --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
+			tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.xz" -C "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidos_image" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
 		"""
 	}
 


### PR DESCRIPTION
Using a glob to cd is weird.
Use ${target.buildtype}, as this is the dir that the glob expands to.