### PR TITLE
Fix variable and image handling

### DIFF
--- a/resources/store-revisions.sh
+++ b/resources/store-revisions.sh
@@ -121,7 +121,7 @@ done
 
 BASE_MANIFEST_PATH="$(dirname "${MANIFEST_PATH}")/gyroidos-base.xml"
 ROLLING_SRCREV=""
-if [ -n "$BH_PATH" ];then
+if [ -n "$BH_PATH" ] && [ -d "$BH_PATH/packages" ];then
 	ROLLING_SRCREV="$(find "$BH_PATH/packages" -wholename '*/linux-*/latest_srcrev')"
 fi
 
@@ -202,7 +202,10 @@ fi
 if [ "y" == "$CML" ]; then
 	echo "Writing CML revisions to auto${AUTO_CONF_SUFFIX}.conf"
 
-	srcrevpath="$(find "$BH_PATH/packages" -wholename '*/cmld/latest_srcrev')"
+	srcrevpath=""
+	if [ -d "$BH_PATH/packages" ];then
+		srcrevpath="$(find "$BH_PATH/packages" -wholename '*/cmld/latest_srcrev')"
+	fi
 	if [ -z "$srcrevpath" ];then
 		echo "Failed to find file */cmld/latest_srcrev in buildhistory, \
 			  attempting to fetch revision from $WS_PATH/gyroidos/cml."

--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -111,16 +111,23 @@ def call(Map target) {
 
 	stepStoreRevisions(workspace: target.workspace, buildtype: "${target.buildtype}", manifest_path: target.manifest_path, manifest_name: target.manifest_name, gyroid_machine: target.gyroid_machine)
 
-	sh label: 'Compress gyroidosimage.img', script: """
-		cd ${target.workspace}/out-${target.buildtype}/tmp/deploy/images/*
-		tar -I "xz -T 0" -C gyroidos_image -cf gyroidosimage.tar.xz --dereference gyroidosimage.img gyroidosimage.img.bmap
-	"""
+	def imageDir = "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidos_image"
+	def installerDir = "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidos_image"
 
-	if (target.containsKey("build_installer") && "y" == target.build_installer) {
-		sh label: 'Compress gyroidosinstaller.img', script: """
-			cd ${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/*
-			tar -I "xz -T 0" -C gyroidos_image -cf gyroidosinstaller.tar.xz --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
+	if (fileExists("${imageDir}/gyroidosimage.img")) {
+		sh label: 'Compress gyroidosimage.img', script: """
+			tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.xz" -C "${imageDir}" --dereference gyroidosimage.img gyroidosimage.img.bmap
 		"""
+	} else {
+		echo "Skipping gyroidosimage.img compression (image not present)"
+	}
+
+	if (target.containsKey("build_installer") && "y" == target.build_installer && fileExists("${installerDir}/gyroidosinstaller.img")) {
+		sh label: 'Compress gyroidosinstaller.img', script: """
+			tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.xz" -C "${installerDir}" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
+		"""
+	} else if (target.containsKey("build_installer") && "y" == target.build_installer) {
+		echo "Skipping gyroidosinstaller.img compression (image not present)"
 	}
 
 	if (target.containsKey("sync_mirrors") && "y" == target.sync_mirrors) {


### PR DESCRIPTION
BH_PATH can be unset, which currently triggers a fault.
Further, we currently unconditionally pack the image/installer tarball. Some build types do not produce image files, thereby currently faulting in this stage.