### PR TITLE
Zstd compression

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -116,7 +116,7 @@ def call(Map target) {
 
 	if (fileExists("${imageDir}/gyroidosimage.img")) {
 		sh label: 'Compress gyroidosimage.img', script: """
-			tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.xz" -C "${imageDir}" --dereference gyroidosimage.img gyroidosimage.img.bmap
+			tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.zst" -C "${imageDir}" --dereference gyroidosimage.img gyroidosimage.img.bmap
 		"""
 	} else {
 		echo "Skipping gyroidosimage.img compression (image not present)"
@@ -124,7 +124,7 @@ def call(Map target) {
 
 	if (target.containsKey("build_installer") && "y" == target.build_installer && fileExists("${installerDir}/gyroidosinstaller.img")) {
 		sh label: 'Compress gyroidosinstaller.img', script: """
-			tar -I "xz -T 0" -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.xz" -C "${installerDir}" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
+			tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.zst" -C "${installerDir}" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
 		"""
 	} else if (target.containsKey("build_installer") && "y" == target.build_installer) {
 		echo "Skipping gyroidosinstaller.img compression (image not present)"
@@ -134,8 +134,8 @@ def call(Map target) {
 		stepSyncMirrors(workspace: target.workspace, mirror_base_path: target.mirror_base_path, yocto_version: target.yocto_version, gyroid_machine: target.gyroid_machine,  buildtype: target.buildtype, build_number: BUILD_NUMBER)
 	}
 
-	archiveArtifacts artifacts: "out-${target.buildtype}/tmp/deploy/images/**/gyroidosimage.tar.xz, \
-				       out-${target.buildtype}/tmp_installer/deploy/images/**/gyroidosinstaller.tar.xz, \
+	archiveArtifacts artifacts: "out-${target.buildtype}/tmp/deploy/images/**/gyroidosimage.tar.zst, \
+				       out-${target.buildtype}/tmp_installer/deploy/images/**/gyroidosinstaller.tar.zst, \
 				       out-${target.buildtype}/test_certificates/**, \
 				       out-${target.buildtype}/tmp/deploy/images/**/ssh-keys/**, \
 				       out-${target.buildtype}/tmp/deploy/images/**/cml_updates/kernel-**.tar, \

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -15,7 +15,7 @@ def integrationTestX86(Map target = [:]) {
 	step ([$class: 'CopyArtifact',
 		projectName: env.JOB_NAME,
 		selector: target.selector,
-		filter: "out-${srcBuild}/**/gyroidosimage.tar.xz, ${target.source_tarball}",
+		filter: "out-${srcBuild}/**/gyroidosimage.tar.zst, ${target.source_tarball}",
 		flatten: true]);
 
 
@@ -44,7 +44,7 @@ def integrationTestX86(Map target = [:]) {
 
 	sh "echo \"Unpacking sources\" && tar -C \"${target.workspace}\" -xf ${target.source_tarball}"
 
-	sh label: "Extract image", script: 'tar -I "xz -T 0" -xf gyroidosimage.tar.xz'
+	sh label: "Extract image", script: 'tar --zstd -xf gyroidosimage.tar.zst'
 
 
 	testscript = libraryResource('VM-container-tests.sh')	


### PR DESCRIPTION
Use zstd instead of xz. `xz -T0` uses all cores, which will lead to write saturation, single-core compression should not impose too large of an overhead.

Testing shows, that compression time stays exactly the same, as does image size. Decompression time halves, from 90s to 45s on disk-backed runners.