### PR TITLE
vars: archive artifacts when the stage fails

### DIFF
--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -109,36 +109,37 @@ def call(Map target) {
 		target.buildSteps()
 	}
 
-	stepStoreRevisions(workspace: target.workspace, buildtype: "${target.buildtype}", manifest_path: target.manifest_path, manifest_name: target.manifest_name, gyroid_machine: target.gyroid_machine)
+	try {
+		stepStoreRevisions(workspace: target.workspace, buildtype: "${target.buildtype}", manifest_path: target.manifest_path, manifest_name: target.manifest_name, gyroid_machine: target.gyroid_machine)
 
-	def imageDir = "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidos_image"
-	def installerDir = "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidos_image"
+		def imageDir = "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidos_image"
+		def installerDir = "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidos_image"
 
-	if (fileExists("${imageDir}/gyroidosimage.img")) {
-		sh label: 'Compress gyroidosimage.img', script: """
-			tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.zst" -C "${imageDir}" --dereference gyroidosimage.img gyroidosimage.img.bmap
-		"""
-	} else {
-		echo "Skipping gyroidosimage.img compression (image not present)"
-	}
+		if (fileExists("${imageDir}/gyroidosimage.img")) {
+			sh label: 'Compress gyroidosimage.img', script: """
+				tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp/deploy/images/${target.gyroid_machine}/gyroidosimage.tar.zst" -C "${imageDir}" --dereference gyroidosimage.img gyroidosimage.img.bmap
+			"""
+		} else {
+			echo "Skipping gyroidosimage.img compression (image not present)"
+		}
 
-	if (target.containsKey("build_installer") && "y" == target.build_installer && fileExists("${installerDir}/gyroidosinstaller.img")) {
-		sh label: 'Compress gyroidosinstaller.img', script: """
-			tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.zst" -C "${installerDir}" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
-		"""
-	} else if (target.containsKey("build_installer") && "y" == target.build_installer) {
-		echo "Skipping gyroidosinstaller.img compression (image not present)"
-	}
+		if (target.containsKey("build_installer") && "y" == target.build_installer && fileExists("${installerDir}/gyroidosinstaller.img")) {
+			sh label: 'Compress gyroidosinstaller.img', script: """
+				tar --zstd -cf "${target.workspace}/out-${target.buildtype}/tmp_installer/deploy/images/${target.gyroid_machine}/gyroidosinstaller.tar.zst" -C "${installerDir}" --dereference gyroidosinstaller.img gyroidosinstaller.img.bmap
+			"""
+		} else if (target.containsKey("build_installer") && "y" == target.build_installer) {
+			echo "Skipping gyroidosinstaller.img compression (image not present)"
+		}
 
-	if (target.containsKey("sync_mirrors") && "y" == target.sync_mirrors) {
-		stepSyncMirrors(workspace: target.workspace, mirror_base_path: target.mirror_base_path, yocto_version: target.yocto_version, gyroid_machine: target.gyroid_machine,  buildtype: target.buildtype, build_number: BUILD_NUMBER)
-	}
-
-	archiveArtifacts artifacts: "out-${target.buildtype}/tmp/deploy/images/**/gyroidosimage.tar.zst, \
-				       out-${target.buildtype}/tmp_installer/deploy/images/**/gyroidosinstaller.tar.zst, \
-				       out-${target.buildtype}/test_certificates/**, \
-				       out-${target.buildtype}/tmp/deploy/images/**/ssh-keys/**, \
-				       out-${target.buildtype}/tmp/deploy/images/**/cml_updates/kernel-**.tar, \
+		if (target.containsKey("sync_mirrors") && "y" == target.sync_mirrors) {
+			stepSyncMirrors(workspace: target.workspace, mirror_base_path: target.mirror_base_path, yocto_version: target.yocto_version, gyroid_machine: target.gyroid_machine,  buildtype: target.buildtype, build_number: BUILD_NUMBER)
+		}
+	} finally {
+		archiveArtifacts artifacts: "out-${target.buildtype}/tmp/deploy/images/**/gyroidosimage.tar.zst, \
+					   out-${target.buildtype}/tmp_installer/deploy/images/**/gyroidosinstaller.tar.zst, \
+					   out-${target.buildtype}/test_certificates/**, \
+					   out-${target.buildtype}/tmp/deploy/images/**/ssh-keys/**, \
+					   out-${target.buildtype}/tmp/deploy/images/**/cml_updates/kernel-**.tar, \
 					   out-${target.buildtype}/tmp/work/**/cmld/**/temp/**, \
 					   out-${target.buildtype}/tmp/work/**/protobuf-c-text/**/temp/**, \
 					   out-${target.buildtype}/tmp/work/**/sc-hsm-embedded/**/temp/**, \
@@ -153,4 +154,5 @@ def call(Map target) {
 					   out-${target.buildtype}/tmp/work/**/gyroidos-cml-modules/**/temp/**, \
 					   out-${target.buildtype}/conf/**, \
 					   out-${target.buildtype}/tmp/log/**, .build_number" , fingerprint: true, allowEmptyArchive: false
+	}
 }

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -76,30 +76,32 @@ def integrationTestX86(Map target = [:]) {
 		}
 	}
 
-	def lockName = target.buildtype in ['schsm', 'bnse'] ? 'tokentest-hsm' : null
+	try {
+		def lockName = target.buildtype in ['schsm', 'bnse'] ? 'tokentest-hsm' : null
 
-	if (lockName) {
-		echo "Acquiring lock '${lockName}' for integration test"
-		lock(lockName) {
+		if (lockName) {
+			echo "Acquiring lock '${lockName}' for integration test"
+			lock(lockName) {
+				runActualTest()
+			}
+		} else {
 			runActualTest()
 		}
-	} else {
-		runActualTest()
-	}
 
-	echo "Archiving CML logs"
-	archiveArtifacts artifacts: 'out-**/cml_logs/**', fingerprint: true, allowEmptyArchive: true
-
-	catchError(message: 'ASAN output detected', stageResult: 'FAILURE') {
-		sh label: "Check whether ASAN logs generated", script: """
-			if ! [ -z "\$(find out-${srcBuild}/cml_logs -name '*asan*')" ];then
-				echo "Found ASAN logs"
-				exit 1
-			else
-				echo "No ASAN logs generated"
-				exit 0
-			fi
-		"""
+		catchError(message: 'ASAN output detected', stageResult: 'FAILURE') {
+			sh label: "Check whether ASAN logs generated", script: """
+				if ! [ -z "\$(find out-${srcBuild}/cml_logs -name '*asan*')" ];then
+					echo "Found ASAN logs"
+					exit 1
+				else
+					echo "No ASAN logs generated"
+					exit 0
+				fi
+			"""
+		}
+	} finally {
+		echo "Archiving CML logs"
+		archiveArtifacts artifacts: 'out-**/cml_logs/**', fingerprint: true, allowEmptyArchive: true
 	}
 }
 


### PR DESCRIPTION
Wrap stage execution into a try-block to ensure that artifacts are archived even when the stage itself fails.

Currently, no artifacts are archived when the stage itself fails.