### PR TITLE
Switch to new CI tokentest handling scripts

### DIFF
--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -380,7 +380,7 @@ fi
 if ! [[ -z "${HSM_SERIAL}" ]]
 then
 	echo_status "Preparing image for test with hsm container"
-	/usr/local/bin/preparetmeimg.sh "$(pwd)/${PROCESS_NAME}.img"
+	/usr/local/bin/local_tokentest_handling.sh prepare_img "$(pwd)/${PROCESS_NAME}.img"
 fi
 
 # Start VM
@@ -532,7 +532,7 @@ if ! [[ -z "${HSM_SERIAL}" ]];then
 	force_stop_vm
 
 	echo_status "Setting container pairing state"
-	/usr/local/bin/preparetmecontainer.sh "$(pwd)/${PROCESS_NAME}.ext4fs"
+	/usr/local/bin/local_tokentest_handling.sh prepare_container "$(pwd)/${PROCESS_NAME}.ext4fs"
 
 	echo_status "Waiting for QEMU to cleanup USB devices"
 	sleep 2

--- a/resources/settings.sh
+++ b/resources/settings.sh
@@ -24,10 +24,6 @@ SCRIPTS_DIR=""
 
 TESTPW="pw"
 
-BASE_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=${PROCESS_NAME}.vm_key -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=5"
-SCP_OPTS="-P $SSH_PORT $BASE_OPTS"
-SSH_OPTS="-p $SSH_PORT $BASE_OPTS root@localhost"
-
 ###################################################################################################
 # COMMAND LINE INTERFACE
 ###################################################################################################
@@ -211,4 +207,8 @@ parse_cli() {
         echo_error "No PKI given, exiting..."
         exit 1
     fi
+
+    BASE_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=${PROCESS_NAME}.vm_key -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=5"
+    SCP_OPTS="-P $SSH_PORT $BASE_OPTS"
+    SSH_OPTS="-p $SSH_PORT $BASE_OPTS root@localhost"
 }

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -59,6 +59,11 @@ def integrationTestX86(Map target = [:]) {
 	writeFile file: "${target.workspace}/settings.sh", text: "${testsettings}"
 	writeFile file: "${target.workspace}/testdata.sh", text: "${testdata}"
 
+	def execNr = env.EXECUTOR_NUMBER?.toInteger() ?: 0
+	def sshPort = target.ssh_port ?: (2222 + execNr)
+	def vncDisplay = target.vnc_display ?: (1 + execNr)
+	def vmName = target.vm_name ?: "testvm-${execNr}"
+
 	def runActualTest = {
 		catchError(message: 'Integration test failed', stageResult: 'FAILURE') {
 			sh label: "Perform integration test", script: """
@@ -71,17 +76,17 @@ def integrationTestX86(Map target = [:]) {
 					echo "Testing image with mode ${target.test_mode}"
 				fi
 
-				CML_DBG=n bash ${target.workspace}/VM-container-tests.sh --mode "${target.test_mode}" --dir "${target.workspace}" --image gyroidosimage.img --pki "${target.workspace}/test_certificates" --name "testvm" --ssh 2222 --kill --vnc 1 --log-dir "${target.workspace}/out-${srcBuild}/cml_logs" \$schsm_opts ${target.extra_opts ? target.extra_opts : ""}
+				CML_DBG=n bash ${target.workspace}/VM-container-tests.sh --mode "${target.test_mode}" --dir "${target.workspace}" --image gyroidosimage.img --pki "${target.workspace}/test_certificates" --name "${vmName}" --ssh ${sshPort} --kill --vnc ${vncDisplay} --log-dir "${target.workspace}/out-${srcBuild}/cml_logs" \$schsm_opts ${target.extra_opts ? target.extra_opts : ""}
 			"""
 		}
 	}
 
 	try {
-		def lockName = target.buildtype in ['schsm', 'bnse'] ? 'tokentest-hsm' : null
-
-		if (lockName) {
-			echo "Acquiring lock '${lockName}' for integration test"
-			lock(lockName) {
+		// HSM-based tests need locking
+		// Negated to be defensive against bugs when adding new HSM types
+		if (!(target.buildtype in ['asan', 'ccmode', 'dev', 'production'])){
+			echo "Acquiring lock '${target.buildtype}' for integration test"
+			lock(target.buildtype) {
 				runActualTest()
 			}
 		} else {


### PR DESCRIPTION
Call the new scripts instead of `preparetme{img,container}.sh`.
The new scripts do not need locking, as they no longer interfere with each other. We thereby remove the locking for the tokentest.
We compute the ssh port and vnc display number based on the Jenkins runner number. This allows multiplexing multiple VMs without the usage of docker.
Move construction BASE_OPTS, SCP_OPTS and SSH_OPTS to the bottom of parse_cli. Currently these are constructed based on values that are influenced by parse_ci, which leads to an incorrect commandline.
