### PR TITLE
vars/stepBuildImage: use less disk space

### DIFF
--- a/resources/VM-container-tests.sh
+++ b/resources/VM-container-tests.sh
@@ -368,8 +368,7 @@ rm -f ${PROCESS_NAME}.img
 
 if ! [[ -z "${IMGPATH}" ]];then
 	echo_status "Testing image at ${IMGPATH}"
-	# Attempt COW copy, fallback to regular cp
-	cp --reflink=auto --dereference "${IMGPATH}" "${PROCESS_NAME}.img"
+	mv -- "${IMGPATH}" "${PROCESS_NAME}.img"
 else
 	echo_status "Testing image at $(pwd)/tmp/deploy/images/genericx86-64/gyroidos_image/gyroidosimage.img"
 	# Attempt COW copy, fallback to regular cp

--- a/vars/stepBuildImage.groovy
+++ b/vars/stepBuildImage.groovy
@@ -79,7 +79,7 @@ def call(Map target) {
 
 			MIRRORPATH="${target.mirror_base_path}/${target.yocto_version}/${target.gyroid_machine}/"
 
-			echo 'GYROIDOS_DATAPART_EXTRA_SPACE="20000"' >> conf/local.conf
+			echo 'GYROIDOS_DATAPART_EXTRA_SPACE="12288"' >> conf/local.conf
 
 			echo "INHERIT += \\\"own-mirrors\\\"" >> conf/local.conf
 			echo "SOURCE_MIRROR_URL = \\\"file://${target.mirror_base_path}/sources/\\\"" >> conf/local.conf

--- a/vars/stepIntegrationTest.groovy
+++ b/vars/stepIntegrationTest.groovy
@@ -42,9 +42,9 @@ def integrationTestX86(Map target = [:]) {
 
 	echo "Using artifacts of build number determined by selector: ${artifact_build_no}"
 
-	sh "echo \"Unpacking sources\" && tar -C \"${target.workspace}\" -xf ${target.source_tarball}"
+	sh "echo \"Unpacking sources\" && tar -C \"${target.workspace}\" -xf ${target.source_tarball} && rm -f ${target.source_tarball}"
 
-	sh label: "Extract image", script: 'tar --zstd -xf gyroidosimage.tar.zst'
+	sh label: "Extract image", script: 'tar --zstd -xf gyroidosimage.tar.zst && rm -f gyroidosimage.tar.zst'
 
 
 	testscript = libraryResource('VM-container-tests.sh')	


### PR DESCRIPTION
Lower disk usage through:
- Lower size of data partition, from 20GB to 12GiB. Image artifacts are thereby smaller.
- Do not create unnecessary copies of image, disk usage halves
- Remove image archives after extraction