### PR TITLE
Test Runner Improvements

### DIFF
--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -141,9 +141,9 @@ start_vm() {
         -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \
         -device virtio-rng-pci,rng=id -object rng-random,id=id,filename=/dev/urandom \
         -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd0 \
-        -drive if=none,id=hd0,file=${PROCESS_NAME}.img,cache=directsync,format=raw \
+        -drive if=none,id=hd0,file=${PROCESS_NAME}.img,cache=writeback,format=raw \
         -device scsi-hd,drive=hd1 \
-        -drive if=none,id=hd1,file=${PROCESS_NAME}.ext4fs,cache=directsync,format=raw \
+        -drive if=none,id=hd1,file=${PROCESS_NAME}.ext4fs,cache=writeback,format=raw \
         -device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp::$SSH_PORT-:22 \
         -drive "if=pflash,format=raw,readonly=on,file=$ovmf_code" \
         -drive "if=pflash,format=raw,file=./OVMF_VARS.fd" \

--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -3,11 +3,11 @@ set -e
 
 sync_to_disk() {
     echo_status "Syncing VM state to disk"
-    for I in $(seq 1 10) ;do 
+    for I in $(seq 1 3) ;do
         if ssh ${SSH_OPTS} 'sh -c sync && sleep 1' 2>&1;then
             echo_status "Synced VM state to disk"
             break
-        elif ! [[ "$I" == "10" ]];then
+        elif ! [[ "$I" == "3" ]];then
             echo_status "Failed to sync VM state to disk, retrying"
             sleep 0.5
         else
@@ -77,30 +77,24 @@ err_fetch_logs() {
 trap 'err_fetch_logs' EXIT INT TERM
 
 wait_vm () {
-    echo_status "Waiting for VM to become available"
+    local timeout_sec=300
+    echo_status "Waiting up to ${timeout_sec}s for VM to become available"
+    # Give QEMU a moment to register its process name before pgrep checks.
     sleep 3
-    # Copy test container config to VM
-    success="n"
-    for I in $(seq 1 100) ;do
-        sleep 1
-
-        if [[ -z "$(pgrep $PROCESS_NAME)" ]];then
+    local deadline=$(($(date +%s) + timeout_sec))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if [[ -z "$(pgrep $PROCESS_NAME)" ]]; then
             echo_status "Error: QEMU process exited"
             exit 1
         fi
-        if ssh -q ${SSH_OPTS} "ls /data" ;then
+        if ssh -q -o ConnectTimeout=5 ${SSH_OPTS} "ls /data" 2>/dev/null; then
             echo_status "VM access was successful"
-            success="y"
-            break
-        else
-            printf "."
+            return
         fi
+        sleep 1
     done
-
-    if [[ "$success" != "y" ]];then
-        echo_status "VM access failed, exiting..."
-        exit 1
-    fi
+    echo_status "VM access failed after ${timeout_sec}s, exiting..."
+    exit 1
 }
 
 start_swtpm() {

--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -136,7 +136,7 @@ start_vm() {
 
     align_image "${PROCESS_NAME}.img"
     align_image "${PROCESS_NAME}.ext4fs"
-    qemu-system-x86_64 -machine accel=kvm,vmport=off -m 64G -smp 4 -cpu host -bios OVMF.fd \
+    qemu-system-x86_64 -machine accel=kvm,vmport=off -m 16G -smp 4 -cpu host -bios OVMF.fd \
         -monitor unix:./${PROCESS_NAME}.qemumon,server,nowait \
         -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \
         -device virtio-rng-pci,rng=id -object rng-random,id=id,filename=/dev/urandom \

--- a/resources/settings.sh
+++ b/resources/settings.sh
@@ -208,7 +208,7 @@ parse_cli() {
         exit 1
     fi
 
-    BASE_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=${PROCESS_NAME}.vm_key -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=5"
+    BASE_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=${PROCESS_NAME}.vm_key -o GlobalKnownHostsFile=/dev/null -o ConnectTimeout=30"
     SCP_OPTS="-P $SSH_PORT $BASE_OPTS"
     SSH_OPTS="-p $SSH_PORT $BASE_OPTS root@localhost"
 }


### PR DESCRIPTION
Change the QEMU disk caching strategy from directsync to writeback, which should aid test runner performance.
Further, reduce the main memory of test VMs from 64GiB to 16GiB.
Rewrite the SSH connection handling to be more robust against jitter and failures during connection into the test VMs.