### PR TITLE
resources/VM-management: Capture kernel and CML serial as artifacts

### DIFF
--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -43,12 +43,16 @@ fetch_logs() {
     # skipped if disk-image extraction below fails.
     echo_status "fetch_logs cwd: $(pwd); workspace contents:"
     ls -al ./ | sed 's/^/  /'
-    if [ -f "./${PROCESS_NAME}.console.log" ]; then
-        cp "./${PROCESS_NAME}.console.log" "${LOG_DIR}/"
-        echo_status "Copied ${PROCESS_NAME}.console.log ($(wc -c < ./${PROCESS_NAME}.console.log) bytes)"
-    else
-        echo_status "WARNING: ./${PROCESS_NAME}.console.log not found"
-    fi
+    for f in "${PROCESS_NAME}.console.log" \
+             "${PROCESS_NAME}.kernel.log" \
+             "${PROCESS_NAME}.cml.log"; do
+        if [ -f "./$f" ]; then
+            cp "./$f" "${LOG_DIR}/"
+            echo_status "Logfile '$f' found"
+        else
+            echo_status "Logfile '$f' NOT found"
+        fi
+    done
     if [ -f "./${PROCESS_NAME}.qemu.stderr" ]; then
         cp "./${PROCESS_NAME}.qemu.stderr" "${LOG_DIR}/"
     fi
@@ -166,7 +170,11 @@ start_vm() {
     align_image "${PROCESS_NAME}.ext4fs"
     # If --telnet wasn't passed, capture guest serial to a file so we can see
     # kernel/initramfs output when the guest dies before cmld writes its logs.
+    # ttyS0: login getty; ttyS1: kernel printk (via dev kernel cmdline);
+    # ttyS2: CML LOGTTY (bind-mounted from /dev/tty11 by cml-boot in dev builds).
     local serial_args="${TELNET:--serial file:./${PROCESS_NAME}.console.log}"
+    serial_args="$serial_args -serial file:./${PROCESS_NAME}.kernel.log"
+    serial_args="$serial_args -serial file:./${PROCESS_NAME}.cml.log"
     qemu-system-x86_64 -machine accel=kvm,vmport=off -m 16G -smp 4 -cpu host -bios OVMF.fd \
         -monitor unix:./${PROCESS_NAME}.qemumon,server,nowait \
         -name gyroidos-tester,process=${PROCESS_NAME} -nodefaults -nographic \

--- a/resources/VM-management.sh
+++ b/resources/VM-management.sh
@@ -27,6 +27,26 @@ force_stop_vm() {
         echo_status "Failed to request clean VM exit"
     fi
 
+    # Wait for the QEMU process to actually exit before returning. Without
+    # this, the next start_vm can race the old QEMU, potentially failing to attach
+	# USB devices.
+    local pid
+    pid="$(pgrep -f "process=${PROCESS_NAME}" || true)"
+    if [ -n "$pid" ]; then
+        echo_status "Waiting up to 15s for QEMU pid $pid to exit"
+        for _ in $(seq 1 30); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.5
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo_status "QEMU pid $pid did not exit in 15s; sending SIGKILL"
+            kill -KILL "$pid" 2>/dev/null || true
+            sleep 1
+        else
+            echo_status "QEMU pid $pid exited"
+        fi
+    fi
+
     rm -f ${PROCESS_NAME}.vm_key
 }
 
@@ -53,9 +73,11 @@ fetch_logs() {
             echo_status "Logfile '$f' NOT found"
         fi
     done
-    if [ -f "./${PROCESS_NAME}.qemu.stderr" ]; then
-        cp "./${PROCESS_NAME}.qemu.stderr" "${LOG_DIR}/"
-    fi
+    for f in "${PROCESS_NAME}.qemu.stderr" "${PROCESS_NAME}.qemu.stdout"; do
+        if [ -f "./$f" ]; then
+            cp "./$f" "${LOG_DIR}/"
+        fi
+    done
 
     # Best-effort extraction of /userdata/logs from the disk image. Wrap in a
     # subshell so set -e failures here don't skip the console-log copy above
@@ -171,7 +193,8 @@ start_vm() {
     # If --telnet wasn't passed, capture guest serial to a file so we can see
     # kernel/initramfs output when the guest dies before cmld writes its logs.
     # ttyS0: login getty; ttyS1: kernel printk (via dev kernel cmdline);
-    # ttyS2: CML LOGTTY (bind-mounted from /dev/tty11 by cml-boot in dev builds).
+    # ttyS2: CML LOGTTY (GYROIDOS_LOGTTY set to ttyS2 in dev x86 builds, so
+    # CML's `exec > /dev/$LOGTTY` writes here directly — no bind mount).
     local serial_args="${TELNET:--serial file:./${PROCESS_NAME}.console.log}"
     serial_args="$serial_args -serial file:./${PROCESS_NAME}.kernel.log"
     serial_args="$serial_args -serial file:./${PROCESS_NAME}.cml.log"
@@ -189,7 +212,7 @@ start_vm() {
         $SWTPM \
         $VNC \
         $serial_args \
-        $PASS_HSM >/dev/null 2>"./${PROCESS_NAME}.qemu.stderr" &
+        $PASS_HSM >"./${PROCESS_NAME}.qemu.stdout" 2>"./${PROCESS_NAME}.qemu.stderr" &
 
     wait_vm
 }


### PR DESCRIPTION
This PR implements the extraction of QEMU{stdout,stderr}, Kernel, and CML logs as logfiles, for DEVELOPMENT builds. We integrate changes over the following repos:
## [meta-gyroidos](https://github.com/gyroidos/meta-gyroidos/pull/309)
- New composable kernel command line in recipes-kernel/linux/linux-gyroidos.inc. Layers and BSP machine configs append to GYROIDOS_KERNEL_CMDLINE; kernel_do_configure:append commits the assembled value (both CONFIG_CMDLINE_BOOL=y and
CONFIG_CMDLINE="…") into the merged .config after merge_config.sh runs. Replaces the CONFIG_CMDLINE="audit=1" line in gyroidos.cfg that previously lost the merge-order race to any layer also setting CONFIG_CMDLINE.
- New dev-only diagnostic fragment recipes-initscripts/cml-boot/files/22-dump-diag.fragment prints /proc/cmdline, ls /dev/ttyS*, and $LOGTTY to the CML log so you can verify routing took effect from CI artifacts (no SSH-into-VM needed).

## [meta-gyroidos-intel](https://github.com/gyroidos/meta-gyroidos-intel/pull/53)
- conf/gyroidos/genericx86-64.inc: overrides GYROIDOS_LOGTTY to ttyS2 in dev/CI builds (was tty11) so CML's existing exec > /dev/$LOGTTY writes directly to a QEMU serial backend — no bind mount, no init-script changes. Sets GYROIDOS_KERNEL_CMDLINE_DEV
= "earlycon=uart8250,io,0x2f8 console=ttyS1,115200" to route kernel printk to ttyS1 in dev/CI builds.
- New recipes-initscripts/cml-boot/cml-boot_%.bbappend adds a static mknod /dev/ttyS2 c 4 66 in dev builds so the early exec > /dev/$LOGTTY (pre-devtmpfs) can open it.

## [meta-tmedbg](https://github.com/gyroidos/meta-tmedbg/pull/12)
- recipes-kernel/linux/linux-%.bbappend now contributes nokaslr via GYROIDOS_KERNEL_CMDLINE += "nokaslr". Previously debugging.cfg set CONFIG_CMDLINE="nokaslr" directly and won the merge race, silently dropping the gyroidos base audit=1.
- recipes-kernel/linux/generic/debugging.cfg: removed the CONFIG_CMDLINE_BOOL and CONFIG_CMDLINE lines; now owned in one place by meta-gyroidos.

## [gyroidos_ci_common](https://github.com/gyroidos/gyroidos_ci_common/pull/79)
- resources/VM-management.sh:
  - start_vm() now passes three -serial file: backends (console.log / kernel.log / cml.log) and redirects QEMU stdout to ${PROCESS_NAME}.qemu.stdout so usb-host warnings (and similar) land in the artifact set.
  - fetch_logs() iterates over the three log files plus stderr+stdout with one consistent if-present-then-copy block.
  - force_stop_vm() now waits up to 15s for the QEMU process to actually exit after the quit monitor command (then SIGKILLs if needed). Fixes a latent USB passthrough race in the hwhsm test: the extra -serial file: backends slow QEMU's flush on exit
enough that the next start_vm would launch before the previous QEMU released its -device usb-host claim, causing lsusb in the guest to show no HSM device and signedcontainer1 to fail with CONTAINER_START_TOKEN_UNINIT.